### PR TITLE
Remove Cloo as a dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,6 @@ StyleCop.Cache
 
 # Ignore ThirdParty
 /Jitter
-/Cloo
 /Newtonsoft.Json
 /protobuf-net
 /Binaries

--- a/Build/Module.xml
+++ b/Build/Module.xml
@@ -12,7 +12,6 @@
   <GenerateNuGetRepositories>true</GenerateNuGetRepositories>
   <Packages>
     <Package Uri="https://protobuild.org/hach-que/Jitter" Folder="Jitter" GitRef="master" />
-    <Package Uri="https://protobuild.org/hach-que/Cloo" Folder="Cloo" GitRef="master" />
     <Package Uri="https-nuget://www.nuget.org/api/v2/|Newtonsoft.Json" Folder="Newtonsoft.Json" GitRef="8.0.3" />
     <Package Uri="https://protobuild.org/hach-que/protobuf-net" Folder="protobuf-net" GitRef="master" />
     <Package Uri="https://protobuild.org/RedpointGames/MonoGame" Folder="MonoGame" GitRef="develop" />

--- a/Build/Projects/Protogame.definition
+++ b/Build/Projects/Protogame.definition
@@ -21,7 +21,6 @@
     <Reference Include="Newtonsoft.Json" />
     <Reference Include="NDesk.Options" />
     <Reference Include="Jitter" />
-    <Reference Include="Cloo" />
     <Reference Include="HiveMP.TemporarySession" />
     <Reference Include="HiveMP.NATPunchthrough" />
     <Reference Include="HiveMP.Lobby" />

--- a/Build/Projects/ProtogamePostGameBuild.definition
+++ b/Build/Projects/ProtogamePostGameBuild.definition
@@ -19,7 +19,6 @@
       <Project Name="Newtonsoft.Json" />
       <Project Name="NDesk.Options" />
       <Project Name="Jitter" />
-      <Project Name="Cloo" />
     </PostBuildHookExcludes>
   </Properties>
   <References>

--- a/Build/Projects/ProtogamePostLibBuild.definition
+++ b/Build/Projects/ProtogamePostLibBuild.definition
@@ -18,7 +18,6 @@
       <Project Name="Newtonsoft.Json" />
       <Project Name="NDesk.Options" />
       <Project Name="Jitter" />
-      <Project Name="Cloo" />
     </PostBuildHookExcludes>
   </Properties>
   <References>

--- a/Protogame/Assets/Effect/UberEffectAsset.cs
+++ b/Protogame/Assets/Effect/UberEffectAsset.cs
@@ -3,7 +3,6 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Cloo;
 using Microsoft.Xna.Framework.Graphics;
 
 namespace Protogame

--- a/README.md
+++ b/README.md
@@ -51,8 +51,7 @@ Projects are built and tested against all supported and experimental platforms.
 | [Prototest](https://github.com/RedpointGames/Prototest) | ![](https://jenkins.redpointgames.com.au/buildStatus/icon?job=RedpointGames/Prototest/master) |
 | [Jitter](https://github.com/RedpointGames/Jitter) (Physics) | ![](https://jenkins.redpointgames.com.au/buildStatus/icon?job=RedpointGames/Jitter/master) |
 | [AStarPathFinder](https://github.com/RedpointGames/AStarPathFinder) | ![](https://jenkins.redpointgames.com.au/buildStatus/icon?job=RedpointGames/AStarPathFinder/master) |
-| [Cloo](https://github.com/RedpointGames/Cloo) (OpenCL) | ![](https://jenkins.redpointgames.com.au/buildStatus/icon?job=RedpointGames/Cloo/master) |
-| [Newtonsoft.Json](https://github.com/RedpointGames/Newtonsoft.Json) | ![](https://jenkins.redpointgames.com.au/buildStatus/icon?job=RedpointGames/Newtonsoft.Json/master) |
+| [Newtonsoft.Json](https://github.com/RedpointGames/Newtonsoft.Json) | From NuGet |
 | [protobuf-net](https://github.com/RedpointGames/protobuf-net) | ![](https://jenkins.redpointgames.com.au/buildStatus/icon?job=RedpointGames/protobuf-net/master) |
 | [NDesk.Options](https://github.com/RedpointGames/NDesk.Options) | ![](https://jenkins.redpointgames.com.au/buildStatus/icon?job=RedpointGames/NDesk.Options/master) |
 | [HiveMP](https://hivemp.com) | From NuGet |


### PR DESCRIPTION
It doesn't look like this library is being maintained any more, and given the range of compute APIs in addition to OpenCL (CUDA, DirectCompute), it doesn't seem to make much sense to keep maintaining this library.

I'd expect any work in future along the lines of compute shaders to be done upstream in MonoGame, since this area is a very hardware-abstraction section of the engine.