### PR TITLE
Disable multisampling by default on non-Windows platforms

### DIFF
--- a/Protogame/Core/CoreGame.cs
+++ b/Protogame/Core/CoreGame.cs
@@ -503,13 +503,25 @@ namespace Protogame
 		{
             deviceInformation.PresentationParameters.RenderTargetUsage =
                 RenderTargetUsage.PreserveContents;
-
+            
+#if PLATFORM_WINDOWS
             // This will select the highest available multisampling.
             deviceInformation.PresentationParameters.MultiSampleCount = 32;
-
-            // On OpenGL platform, we need to set this to true otherwise it
-            // won't use multisampling regardless of whether we configure it.
             _graphicsDeviceManager.PreferMultiSampling = true;
+#else
+            // On non-Windows platforms, MonoGame's support for multisampling is
+            // just totally broken.  Even if we ask for it here, the maximum
+            // allowable multisampling for the platform won't be detected, which
+            // causes render target corruption later on if we try and create
+            // render targets with the presentation parameter's multisample
+            // count.  This is because on Windows, the property of MultiSampleCount
+            // is adjusted down from 32 to whatever multisampling value is actually
+            // available, but this does not occur for OpenGL platforms, and so
+            // the render targets on OpenGL platforms aren't initialised to a valid
+            // state for the GPU to use.
+            deviceInformation.PresentationParameters.MultiSampleCount = 0;
+            _graphicsDeviceManager.PreferMultiSampling = false;
+#endif
         }
 
         /// <summary>


### PR DESCRIPTION
After much investigation, the cause for render target corruption on macOS was the fact that MonoGame does not update the MultiSampleCount property of the presentation parameters once the OpenGL device is initialised.  Because this property is not initialised, it means that requests to create render targets with the RenderTarget2D constructor get passed a value of 32, which is invalid on almost every platform.  However, MonoGame (and OpenGL) don't throw an error when passed a multisampling count too high for the render target, so instead you just get a render target that is always corrupted and that you can't do anything useful with.

Until MonoGame gets better support for multisampling on non-Windows platforms, we're just going to leave multisampling off by default (developers can override PrepareDeviceSettings in their game if they want to force it on).