### PR TITLE
Fix render pipeline tests due to SurfaceFormat change

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,49 +1,56 @@
 #!/usr/bin/env groovy
-stage("Windows") {
-  node('windows') {
-    checkout poll: false, changelog: false, scm: scm
-    bat ("git clean -xdff")
-    bat ("Protobuild.exe --upgrade-all")
-    try {
-      bat ('Protobuild.exe --automated-build')
-      stash includes: '*.nupkg', name: 'windows-packages'
-    } finally {
-      publishHTML([allowMissing: true, alwaysLinkToLastBuild: true, keepAll: true, reportDir: 'Protogame.Tests/bin/Windows/AnyCPU/Debug/VisualHTML', reportFiles: 'index.html', reportName: 'Visual Test Report - Windows'])
+stage("Build") {
+  parallel (
+    "Windows" : {
+      node('windows') {
+        checkout poll: false, changelog: false, scm: scm
+        bat ("git clean -xdff")
+        bat ("Protobuild.exe --upgrade-all")
+        try {
+          bat ('Protobuild.exe --automated-build')
+          stash includes: '*.nupkg', name: 'windows-packages'
+        } finally {
+          publishHTML([allowMissing: true, alwaysLinkToLastBuild: true, keepAll: true, reportDir: 'Protogame.Tests/bin/Windows/AnyCPU/Debug/VisualHTML', reportFiles: 'index.html', reportName: 'Visual Test Report - Windows'])
+        }
+      }
+    },
+    "Mac": {
+      node('mac') {
+        checkout poll: false, changelog: false, scm: scm
+        sh ("git clean -xdff")
+        sh ("mono Protobuild.exe --upgrade-all MacOS")
+        sh ("mono Protobuild.exe --upgrade-all Android")
+        sh ("mono Protobuild.exe --upgrade-all iOS")
+        try {
+          sh ("mono Protobuild.exe --automated-build")
+          stash includes: '*.nupkg', name: 'mac-packages'
+        } finally {
+          publishHTML([allowMissing: true, alwaysLinkToLastBuild: true, keepAll: true, reportDir: 'Protogame.Tests/bin/MacOS/AnyCPU/Debug/VisualHTML', reportFiles: 'index.html', reportName: 'Visual Test Report - macOS'])
+        }
+      }
+    },
+    "Linux": {
+      node('linux') {
+        checkout poll: true, changelog: true, scm: scm
+        sh ("git clean -xdff")
+        sh ("bash -c 'Xorg -noreset +extension GLX +extension RANDR +extension RENDER -config /xorg.conf :2 & echo \"\$!\" > xorg.pid'")
+        try {
+          sh ("mono Protobuild.exe --upgrade-all")
+          try {
+            sh ("DISPLAY=:2 mono Protobuild.exe --automated-build")
+            stash includes: '*.nupkg', name: 'linux-packages'
+          } finally {
+            sh ("if [ -e xorg.pid ]; then kill \$(<xorg.pid); fi")
+          }
+        } finally {
+          publishHTML([allowMissing: true, alwaysLinkToLastBuild: true, keepAll: true, reportDir: 'Protogame.Tests/bin/Linux/AnyCPU/Debug/VisualHTML', reportFiles: 'index.html', reportName: 'Visual Test Report - Linux'])
+        }
+      }
     }
-  }
+  )
 }
 
-stage("Mac") {
-  node('mac') {
-    checkout poll: false, changelog: false, scm: scm
-    sh ("git clean -xdff")
-    sh ("mono Protobuild.exe --upgrade-all MacOS")
-    sh ("mono Protobuild.exe --upgrade-all Android")
-    sh ("mono Protobuild.exe --upgrade-all iOS")
-    try {
-      sh ("mono Protobuild.exe --automated-build")
-      stash includes: '*.nupkg', name: 'mac-packages'
-    } finally {
-      publishHTML([allowMissing: true, alwaysLinkToLastBuild: true, keepAll: true, reportDir: 'Protogame.Tests/bin/MacOS/AnyCPU/Debug/VisualHTML', reportFiles: 'index.html', reportName: 'Visual Test Report - macOS'])
-    }
-  }
-}
-
-stage("Linux") {
-  node('linux') {
-    checkout poll: true, changelog: true, scm: scm
-    sh ("git clean -xdff")
-    sh ("mono Protobuild.exe --upgrade-all")
-    try {
-      sh ("mono Protobuild.exe --automated-build")
-      stash includes: '*.nupkg', name: 'linux-packages'
-    } finally {
-      publishHTML([allowMissing: true, alwaysLinkToLastBuild: true, keepAll: true, reportDir: 'Protogame.Tests/bin/Linux/AnyCPU/Debug/VisualHTML', reportFiles: 'index.html', reportName: 'Visual Test Report - Linux'])
-    }
-  }
-}
-
-stage("Unified") {
+stage("Package") {
   node('windows') {
     // Ensure a seperate working directory to the normal linux node above.
     ws {

--- a/Protogame/Graphics/DefaultCaptureInlinePostProcessingRenderPass.cs
+++ b/Protogame/Graphics/DefaultCaptureInlinePostProcessingRenderPass.cs
@@ -32,7 +32,7 @@ namespace Protogame
         {
             if (RenderPipelineStateAvailable != null)
             {
-                RenderPipelineStateAvailable(postProcessingSource);
+                RenderPipelineStateAvailable(gameContext, renderContext, previousPass, postProcessingSource);
             }
 
             // Blit to the output.
@@ -45,6 +45,6 @@ namespace Protogame
 
         public string Name { get; set; }
 
-        public Action<RenderTarget2D> RenderPipelineStateAvailable { get; set; }
+        public Action<IGameContext, IRenderContext, IRenderPass, RenderTarget2D> RenderPipelineStateAvailable { get; set; }
     }
 }

--- a/Protogame/Graphics/ICaptureInlinePostProcessingRenderPass.cs
+++ b/Protogame/Graphics/ICaptureInlinePostProcessingRenderPass.cs
@@ -19,6 +19,6 @@ namespace Protogame
         /// render pass.  This callback makes the current source render
         /// target available for capture.
         /// </summary>
-        Action<RenderTarget2D> RenderPipelineStateAvailable { get; set; }
+        Action<IGameContext, IRenderContext, IRenderPass, RenderTarget2D> RenderPipelineStateAvailable { get; set; }
     }
 }


### PR DESCRIPTION
The render pipeline tests use the SaveAsPng function to save the state of the render pipeline.  Due to a fix that was previously made to support MSAA in the render pipeline, the render target being passed through to the tests no longer has a SurfaceFormat of Color, and the SaveAsPng function doesn't support the new format.

This makes the tests blit the render target onto another render target whose SurfaceFormat is explicitly Color, thus allowing SaveAsPng to work again.