### PR TITLE
Breaking changes: Remove host dependent classes from IGameContext, ICoreGame and IHostGame

### DIFF
--- a/Build/Projects/Protogame.definition
+++ b/Build/Projects/Protogame.definition
@@ -279,6 +279,7 @@
     <Compile Include="Console\NullLogShipping.cs" />
     <Compile Include="Console\PendingLogForShip.cs" />
     <Compile Include="Console\ServerConsole.cs" />
+    <Compile Include="Core\BackBufferSize.cs" />
     <Compile Include="Core\BoundingBox.cs" />
     <Compile Include="Core\ConfigurationAttribute.cs" />
     <Compile Include="Core\CoreGame.cs" />

--- a/Protogame.Tests/RenderPipelineTests.cs
+++ b/Protogame.Tests/RenderPipelineTests.cs
@@ -114,7 +114,7 @@ namespace Protogame.Tests
                         return;
                     }
 
-                    _renderTarget = _renderTargetBackBufferUtilities.UpdateCustomRenderTarget(_renderTarget, gameContext, SurfaceFormat.Color, DepthFormat.None, 1);
+                    _renderTarget = _renderTargetBackBufferUtilities.UpdateCustomRenderTarget(_renderTarget, renderContext, SurfaceFormat.Color, DepthFormat.None, 1);
 
                     // Blit to the capture target.
                     _graphicsBlit.Blit(renderContext, d, _renderTarget);
@@ -314,8 +314,8 @@ namespace Protogame.Tests
             {
                 base.PrepareDeviceSettings(deviceInformation);
 
-                this.GraphicsDeviceManager.PreferredBackBufferWidth = Width;
-                this.GraphicsDeviceManager.PreferredBackBufferHeight = Height;
+                deviceInformation.PresentationParameters.BackBufferWidth = Width;
+                deviceInformation.PresentationParameters.BackBufferHeight = Height;
             }
         }
 

--- a/Protogame/Camera/FirstPersonCamera.cs
+++ b/Protogame/Camera/FirstPersonCamera.cs
@@ -29,7 +29,7 @@ namespace Protogame
             float farPlaneDistance)
         {
             var size = _backBufferDimensions.GetSize(renderContext.GraphicsDevice);
-            var aspectRatio = size.X / (float)size.Y;
+            var aspectRatio = size.Width / (float)size.Height;
 
             up = up ?? Vector3.Up;
             renderContext.CameraPosition = position;

--- a/Protogame/Camera/PanningCamera.cs
+++ b/Protogame/Camera/PanningCamera.cs
@@ -30,8 +30,8 @@ namespace Protogame
                     Matrix.CreateTranslation(
                         -new Vector3(centerOfScreenPosition, 0)
                         + new Vector3(
-                            (batchedRenderPass.Viewport?.Width ?? size.X) / 2,
-                            (batchedRenderPass.Viewport?.Height ?? size.Y) / 2,
+                            (batchedRenderPass.Viewport?.Width ?? size.Width) / 2,
+                            (batchedRenderPass.Viewport?.Height ?? size.Height) / 2,
                             0)));
             }
         }

--- a/Protogame/Core/BackBufferSize.cs
+++ b/Protogame/Core/BackBufferSize.cs
@@ -1,0 +1,32 @@
+﻿using System;
+
+namespace Protogame
+{
+    /// <summary>
+    /// Represents the backbuffer size returned from <see cref="IBackBufferDimensions"/>.
+    /// </summary>
+    [Serializable]
+    public struct BackBufferSize
+    {
+        /// <summary>
+        /// Construct a new <see cref="BackBufferSize"/> with the given width and height.
+        /// </summary>
+        /// <param name="width">The backbuffer width.</param>
+        /// <param name="height">The backbuffer height.</param>
+        public BackBufferSize(int width, int height)
+        {
+            Width = width;
+            Height = height;
+        }
+
+        /// <summary>
+        /// The width of the backbuffer.
+        /// </summary>
+        public int Width { get; set; }
+
+        /// <summary>
+        /// The height of the backbuffer.
+        /// </summary>
+        public int Height { get; set; }
+    }
+}

--- a/Protogame/Core/DefaultBackBufferDimensions.cs
+++ b/Protogame/Core/DefaultBackBufferDimensions.cs
@@ -5,9 +5,9 @@ namespace Protogame
 {
     public class DefaultBackBufferDimensions : IBackBufferDimensions
     {
-        public Point GetSize(GraphicsDevice graphicsDevice)
+        public BackBufferSize GetSize(GraphicsDevice graphicsDevice)
         {
-            return new Point(
+            return new BackBufferSize(
                 graphicsDevice.PresentationParameters.BackBufferWidth,
                 graphicsDevice.PresentationParameters.BackBufferHeight);
         }

--- a/Protogame/Core/DefaultGameContext.cs
+++ b/Protogame/Core/DefaultGameContext.cs
@@ -30,7 +30,6 @@ namespace Protogame
             IKernel kernel,
             IAnalyticsEngine analyticsEngine,
             ICoreGame game, 
-            GraphicsDeviceManager graphics, 
             IGameWindow window, 
             IWorld world, 
             IWorldManager worldManager)
@@ -40,7 +39,6 @@ namespace Protogame
             _coroutine = kernel.Get<ICoroutine>();
 
             Game = game;
-            Graphics = graphics;
             World = world;
             WorldManager = worldManager;
             Window = window;
@@ -53,8 +51,6 @@ namespace Protogame
         public ICoreGame Game { get; }
         
         public GameTime GameTime { get; set; }
-        
-        public GraphicsDeviceManager Graphics { get; }
         
         public IGameWindow Window { get; }
         
@@ -123,9 +119,7 @@ namespace Protogame
                 return;
             }
 
-            Graphics.PreferredBackBufferWidth = width;
-            Graphics.PreferredBackBufferHeight = height;
-            Graphics.ApplyChanges();
+            Window.Resize(width, height);
         }
         
         public void SwitchWorld<T>() where T : IWorld

--- a/Protogame/Core/IBackBufferDimensions.cs
+++ b/Protogame/Core/IBackBufferDimensions.cs
@@ -5,6 +5,6 @@ namespace Protogame
 {
     public interface IBackBufferDimensions
     {
-        Point GetSize(GraphicsDevice graphicsDevice);
+        BackBufferSize GetSize(GraphicsDevice graphicsDevice);
     }
 }

--- a/Protogame/Core/ICoreGame.cs
+++ b/Protogame/Core/ICoreGame.cs
@@ -12,8 +12,6 @@ namespace Protogame
 
         GraphicsDevice GraphicsDevice { get; }
 
-        GraphicsDeviceManager GraphicsDeviceManager { get; }
-
         IGameContext GameContext { get; }
         
         IRenderContext RenderContext { get; }

--- a/Protogame/Core/IGameContext.cs
+++ b/Protogame/Core/IGameContext.cs
@@ -46,14 +46,6 @@ namespace Protogame
         GameTime GameTime { get; set; }
 
         /// <summary>
-        /// Gets the graphics device manager, which provide a high-level API to the graphics device.
-        /// </summary>
-        /// <value>
-        /// The graphics device manager.
-        /// </value>
-        GraphicsDeviceManager Graphics { get; }
-
-        /// <summary>
         /// Gets the game window.
         /// </summary>
         /// <value>

--- a/Protogame/Core/IGameWindow.cs
+++ b/Protogame/Core/IGameWindow.cs
@@ -34,14 +34,22 @@ namespace Protogame
         bool AllowUserResizing { get; set; }
 
         /// <summary>
-        /// The underlying MonoGame window object.  The type and presence of this property
-        /// varies per-platform, so it's access should always be within a platform specific block.
+        /// Resize the game window to the specified dimensions.
         /// </summary>
-#if PLATFORM_WINDOWS || PLATFORM_MACOS || PLATFORM_LINUX || PLATFORM_WEB || PLATFORM_IOS
-        GameWindow PlatformWindow { get; }
-#elif PLATFORM_ANDROID || PLATFORM_OUYA
-        Microsoft.Xna.Framework.AndroidGameWindow PlatformWindow { get; }
-#endif
+        /// <param name="width">The new width of the window.</param>
+        /// <param name="height">The new height of the window.</param>
+        void Resize(int width, int height);
+
+        /// <summary>
+        /// Gets whether or not the game is currently in fullscreen mode.
+        /// </summary>
+        bool IsFullscreen { get; }
+
+        /// <summary>
+        /// Turns fullscreen mode on or off immediately.
+        /// </summary>
+        /// <param name="fullscreen">True if the game should be fullscreen, false otherwise.</param>
+        void SetFullscreen(bool fullscreen);
 
         /// <summary>
         /// Sets the position of the mouse cursor on the screen, relative to the window.

--- a/Protogame/Core/IHostGame.cs
+++ b/Protogame/Core/IHostGame.cs
@@ -11,13 +11,9 @@ namespace Protogame
 
         GraphicsDevice GraphicsDevice { get; }
 
-        GraphicsDeviceManager GraphicsDeviceManager { get; }
-
         IGameWindow ProtogameWindow { get; }
 
         event EventHandler<EventArgs> Exiting;
-
-        GameWindow Window { get; }
 
         GameServiceContainer Services { get; }
 

--- a/Protogame/Graphics/Default3DDeferredRenderPass.cs
+++ b/Protogame/Graphics/Default3DDeferredRenderPass.cs
@@ -107,12 +107,12 @@ namespace Protogame
                 return;
             }
 
-            _colorRenderTarget = _renderTargetBackBufferUtilities.UpdateCustomRenderTarget(_colorRenderTarget, gameContext, SurfaceFormat.Color, DepthFormat.Depth24, null);
-            _normalRenderTarget = _renderTargetBackBufferUtilities.UpdateCustomRenderTarget(_normalRenderTarget, gameContext, SurfaceFormat.Color, DepthFormat.None, null);
-            _depthRenderTarget = _renderTargetBackBufferUtilities.UpdateCustomRenderTarget(_depthRenderTarget, gameContext, SurfaceFormat.Single, DepthFormat.None, null);
-            _specularRenderTarget = _renderTargetBackBufferUtilities.UpdateCustomRenderTarget(_specularRenderTarget, gameContext, SurfaceFormat.Color, DepthFormat.None, null);
-            _diffuseLightRenderTarget = _renderTargetBackBufferUtilities.UpdateCustomRenderTarget(_diffuseLightRenderTarget, gameContext, null, DepthFormat.None, null);
-            _specularLightRenderTarget = _renderTargetBackBufferUtilities.UpdateCustomRenderTarget(_specularLightRenderTarget, gameContext, null, DepthFormat.None, null);
+            _colorRenderTarget = _renderTargetBackBufferUtilities.UpdateCustomRenderTarget(_colorRenderTarget, renderContext, SurfaceFormat.Color, DepthFormat.Depth24, null);
+            _normalRenderTarget = _renderTargetBackBufferUtilities.UpdateCustomRenderTarget(_normalRenderTarget, renderContext, SurfaceFormat.Color, DepthFormat.None, null);
+            _depthRenderTarget = _renderTargetBackBufferUtilities.UpdateCustomRenderTarget(_depthRenderTarget, renderContext, SurfaceFormat.Single, DepthFormat.None, null);
+            _specularRenderTarget = _renderTargetBackBufferUtilities.UpdateCustomRenderTarget(_specularRenderTarget, renderContext, SurfaceFormat.Color, DepthFormat.None, null);
+            _diffuseLightRenderTarget = _renderTargetBackBufferUtilities.UpdateCustomRenderTarget(_diffuseLightRenderTarget, renderContext, null, DepthFormat.None, null);
+            _specularLightRenderTarget = _renderTargetBackBufferUtilities.UpdateCustomRenderTarget(_specularLightRenderTarget, renderContext, null, DepthFormat.None, null);
 
             if (_rasterizerStateCullNone == null)
             {
@@ -245,8 +245,8 @@ namespace Protogame
                 _rasterizerStateCullClockwiseFace,
                 _rasterizerStateCullCounterClockwiseFace,
                 new Vector2(
-                    0.5f/size.X,
-                    0.5f/size.Y));
+                    0.5f/size.Width,
+                    0.5f/size.Height));
 
             var lights = new List<ILight>();
 

--- a/Protogame/Graphics/DefaultCanvasRenderPass.cs
+++ b/Protogame/Graphics/DefaultCanvasRenderPass.cs
@@ -51,8 +51,8 @@ namespace Protogame
                 renderContext.GraphicsDevice.Viewport = new Viewport(
                     0,
                     0,
-                    size.X,
-                    size.Y);
+                    size.Width,
+                    size.Height);
             }
 
 #if PLATFORM_WINDOWS

--- a/Protogame/Graphics/DefaultCaptureCopyPostProcessingRenderPass.cs
+++ b/Protogame/Graphics/DefaultCaptureCopyPostProcessingRenderPass.cs
@@ -34,7 +34,7 @@ namespace Protogame
         public void BeginRenderPass(IGameContext gameContext, IRenderContext renderContext, IRenderPass previousPass,
             RenderTarget2D postProcessingSource)
         {
-            _renderTarget = _renderTargetBackBufferUtilities.UpdateRenderTarget(_renderTarget, gameContext);
+            _renderTarget = _renderTargetBackBufferUtilities.UpdateRenderTarget(_renderTarget, renderContext);
 
             // Blit to the capture target.
             _graphicsBlit.Blit(renderContext, postProcessingSource, _renderTarget);

--- a/Protogame/Graphics/DefaultGraphicsBlit.cs
+++ b/Protogame/Graphics/DefaultGraphicsBlit.cs
@@ -99,8 +99,8 @@ namespace Protogame
             {
                 // TODO: renderContext.GraphicsDevice.GetRenderTargets();
                 var backBufferSize = _backBufferDimensions.GetSize(renderContext.GraphicsDevice);
-                destWidth = backBufferSize.X;
-                destHeight = backBufferSize.Y;
+                destWidth = backBufferSize.Width;
+                destHeight = backBufferSize.Height;
             }
 
             offset = offset ?? new Vector2(0, 0);

--- a/Protogame/Graphics/DefaultRenderPipeline.cs
+++ b/Protogame/Graphics/DefaultRenderPipeline.cs
@@ -87,8 +87,8 @@ namespace Protogame
                     renderContext.GraphicsDevice.Viewport.MaxDepth,
                     0);
 
-                _primary = _renderTargetBackBufferUtilities.UpdateRenderTarget(_primary, gameContext);
-                _secondary = _renderTargetBackBufferUtilities.UpdateRenderTarget(_secondary, gameContext);
+                _primary = _renderTargetBackBufferUtilities.UpdateRenderTarget(_primary, renderContext);
+                _secondary = _renderTargetBackBufferUtilities.UpdateRenderTarget(_secondary, renderContext);
 
                 if (_primary == null || _secondary == null)
                 {
@@ -335,8 +335,8 @@ namespace Protogame
                 newViewport = new Viewport(
                     0,
                     0,
-                    size.X,
-                    size.Y);
+                    size.Width,
+                    size.Height);
             }
 
             var currentViewport = renderContext.GraphicsDevice.Viewport;

--- a/Protogame/Graphics/DefaultRenderTargetBackBufferUtilities.cs
+++ b/Protogame/Graphics/DefaultRenderTargetBackBufferUtilities.cs
@@ -18,38 +18,38 @@ namespace Protogame
             _backBufferDimensions = backBufferDimensions;
         }
 
-        public RenderTarget2D UpdateRenderTarget(RenderTarget2D renderTarget, IGameContext gameContext)
+        public RenderTarget2D UpdateRenderTarget(RenderTarget2D renderTarget, IRenderContext renderContext)
         {
-            if (IsRenderTargetOutOfDate(renderTarget, gameContext))
+            if (IsRenderTargetOutOfDate(renderTarget, renderContext))
             {
                 if (renderTarget != null)
                 {
                     renderTarget.Dispose();
                 }
 
-                var size = _backBufferDimensions.GetSize(gameContext.Graphics.GraphicsDevice);
+                var size = _backBufferDimensions.GetSize(renderContext.GraphicsDevice);
 
-                if (size.X == 0 && size.Y == 0)
+                if (size.Width == 0 && size.Height == 0)
                 {
                     return null;
                 }
 
                 renderTarget = new RenderTarget2D(
-                    gameContext.Graphics.GraphicsDevice,
-                    size.X,
-                    size.Y,
+                    renderContext.GraphicsDevice,
+                    size.Width,
+                    size.Height,
                     false,
-                    GetRealBackBufferFormat(gameContext.Graphics.GraphicsDevice.PresentationParameters.BackBufferFormat),
-                    gameContext.Graphics.GraphicsDevice.PresentationParameters.DepthStencilFormat,
-                    gameContext.Graphics.GraphicsDevice.PresentationParameters.MultiSampleCount,
+                    GetRealBackBufferFormat(renderContext.GraphicsDevice.PresentationParameters.BackBufferFormat),
+                    renderContext.GraphicsDevice.PresentationParameters.DepthStencilFormat,
+                    renderContext.GraphicsDevice.PresentationParameters.MultiSampleCount,
                     RenderTargetUsage.PreserveContents);
             }
 
             return renderTarget;
         }
-        public RenderTarget2D UpdateSizedRenderTarget(RenderTarget2D renderTarget, IGameContext gameContext, Vector2 size)
+        public RenderTarget2D UpdateSizedRenderTarget(RenderTarget2D renderTarget, IRenderContext renderContext, Vector2 size)
         {
-            if (IsSizedRenderTargetOutOfDate(renderTarget, gameContext, size))
+            if (IsSizedRenderTargetOutOfDate(renderTarget, renderContext, size))
             {
                 if (renderTarget != null)
                 {
@@ -63,52 +63,52 @@ namespace Protogame
                 }
 
                 renderTarget = new RenderTarget2D(
-                    gameContext.Graphics.GraphicsDevice,
+                    renderContext.GraphicsDevice,
                     (int)size.X,
                     (int)size.Y,
                     false,
-                    GetRealBackBufferFormat(gameContext.Graphics.GraphicsDevice.PresentationParameters.BackBufferFormat),
-                    gameContext.Graphics.GraphicsDevice.PresentationParameters.DepthStencilFormat,
-                    gameContext.Graphics.GraphicsDevice.PresentationParameters.MultiSampleCount,
+                    GetRealBackBufferFormat(renderContext.GraphicsDevice.PresentationParameters.BackBufferFormat),
+                    renderContext.GraphicsDevice.PresentationParameters.DepthStencilFormat,
+                    renderContext.GraphicsDevice.PresentationParameters.MultiSampleCount,
                     RenderTargetUsage.PreserveContents);
             }
 
             return renderTarget;
         }
 
-        public RenderTarget2D UpdateCustomRenderTarget(RenderTarget2D renderTarget, IGameContext gameContext, SurfaceFormat? surfaceFormat, DepthFormat? depthFormat, int? multiSampleCount)
+        public RenderTarget2D UpdateCustomRenderTarget(RenderTarget2D renderTarget, IRenderContext renderContext, SurfaceFormat? surfaceFormat, DepthFormat? depthFormat, int? multiSampleCount)
         {
-            if (IsCustomRenderTargetOutOfDate(renderTarget, gameContext, surfaceFormat, depthFormat, multiSampleCount))
+            if (IsCustomRenderTargetOutOfDate(renderTarget, renderContext, surfaceFormat, depthFormat, multiSampleCount))
             {
                 if (renderTarget != null)
                 {
                     renderTarget.Dispose();
                 }
 
-                var size = _backBufferDimensions.GetSize(gameContext.Graphics.GraphicsDevice);
+                var size = _backBufferDimensions.GetSize(renderContext.GraphicsDevice);
 
-                if (size.X == 0 && size.Y == 0)
+                if (size.Width == 0 && size.Height == 0)
                 {
                     return null;
                 }
 
                 renderTarget = new RenderTarget2D(
-                    gameContext.Graphics.GraphicsDevice,
-                    size.X,
-                    size.Y,
+                    renderContext.GraphicsDevice,
+                    size.Width,
+                    size.Height,
                     false,
-                    surfaceFormat ?? GetRealBackBufferFormat(gameContext.Graphics.GraphicsDevice.PresentationParameters.BackBufferFormat),
-                    depthFormat ?? gameContext.Graphics.GraphicsDevice.PresentationParameters.DepthStencilFormat,
-                    multiSampleCount ?? gameContext.Graphics.GraphicsDevice.PresentationParameters.MultiSampleCount,
+                    surfaceFormat ?? GetRealBackBufferFormat(renderContext.GraphicsDevice.PresentationParameters.BackBufferFormat),
+                    depthFormat ?? renderContext.GraphicsDevice.PresentationParameters.DepthStencilFormat,
+                    multiSampleCount ?? renderContext.GraphicsDevice.PresentationParameters.MultiSampleCount,
                     RenderTargetUsage.PreserveContents);
             }
 
             return renderTarget;
         }
 
-        public RenderTarget2D UpdateCustomSizedRenderTarget(RenderTarget2D renderTarget, IGameContext gameContext, Vector2 size, SurfaceFormat? surfaceFormat, DepthFormat? depthFormat, int? multiSampleCount)
+        public RenderTarget2D UpdateCustomSizedRenderTarget(RenderTarget2D renderTarget, IRenderContext renderContext, Vector2 size, SurfaceFormat? surfaceFormat, DepthFormat? depthFormat, int? multiSampleCount, bool? shared)
         {
-            if (IsCustomSizedRenderTargetOutOfDate(renderTarget, gameContext, size, surfaceFormat, depthFormat, multiSampleCount))
+            if (IsCustomSizedRenderTargetOutOfDate(renderTarget, renderContext, size, surfaceFormat, depthFormat, multiSampleCount))
             {
                 if (renderTarget != null)
                 {
@@ -122,14 +122,22 @@ namespace Protogame
                 }
 
                 renderTarget = new RenderTarget2D(
-                    gameContext.Graphics.GraphicsDevice,
+                    renderContext.GraphicsDevice,
                     (int)size.X,
                     (int)size.Y,
                     false,
-                    surfaceFormat ?? GetRealBackBufferFormat(gameContext.Graphics.GraphicsDevice.PresentationParameters.BackBufferFormat),
-                    depthFormat ?? gameContext.Graphics.GraphicsDevice.PresentationParameters.DepthStencilFormat,
-                    multiSampleCount ?? gameContext.Graphics.GraphicsDevice.PresentationParameters.MultiSampleCount,
-                    RenderTargetUsage.PreserveContents);
+                    surfaceFormat ?? GetRealBackBufferFormat(renderContext.GraphicsDevice.PresentationParameters.BackBufferFormat),
+                    depthFormat ?? renderContext.GraphicsDevice.PresentationParameters.DepthStencilFormat,
+                    multiSampleCount ?? renderContext.GraphicsDevice.PresentationParameters.MultiSampleCount,
+                    RenderTargetUsage.PreserveContents,
+                    shared ?? false);
+
+#if PLATFORM_WINDOWS
+                if (shared ?? false)
+                {
+                    renderTarget.AcquireLock(0, 1000000);
+                }
+#endif
             }
 
             return renderTarget;
@@ -149,7 +157,7 @@ namespace Protogame
 #endif
         }
 
-        public bool IsRenderTargetOutOfDate(RenderTarget2D renderTarget, IGameContext gameContext)
+        public bool IsRenderTargetOutOfDate(RenderTarget2D renderTarget, IRenderContext renderContext)
         {
             if (renderTarget == null)
             {
@@ -157,29 +165,29 @@ namespace Protogame
             }
             else
             {
-                var size = _backBufferDimensions.GetSize(gameContext.Graphics.GraphicsDevice);
+                var size = _backBufferDimensions.GetSize(renderContext.GraphicsDevice);
 
-                if (renderTarget.Width != size.X)
+                if (renderTarget.Width != size.Width)
                 {
                     return true;
                 }
 
-                if (renderTarget.Height != size.Y)
+                if (renderTarget.Height != size.Height)
                 {
                     return true;
                 }
 
-                if (renderTarget.Format != GetRealBackBufferFormat(gameContext.Graphics.GraphicsDevice.PresentationParameters.BackBufferFormat))
+                if (renderTarget.Format != GetRealBackBufferFormat(renderContext.GraphicsDevice.PresentationParameters.BackBufferFormat))
                 {
                     return true;
                 }
 
-                if (renderTarget.DepthStencilFormat != gameContext.Graphics.GraphicsDevice.PresentationParameters.DepthStencilFormat)
+                if (renderTarget.DepthStencilFormat != renderContext.GraphicsDevice.PresentationParameters.DepthStencilFormat)
                 {
                     return true;
                 }
 
-                if (renderTarget.MultiSampleCount != gameContext.Graphics.GraphicsDevice.PresentationParameters.MultiSampleCount)
+                if (renderTarget.MultiSampleCount != renderContext.GraphicsDevice.PresentationParameters.MultiSampleCount)
                 {
                     return true;
                 }
@@ -188,7 +196,7 @@ namespace Protogame
             return false;
         }
 
-        public bool IsSizedRenderTargetOutOfDate(RenderTarget2D renderTarget, IGameContext gameContext, Vector2 size)
+        public bool IsSizedRenderTargetOutOfDate(RenderTarget2D renderTarget, IRenderContext renderContext, Vector2 size)
         {
             if (renderTarget == null)
             {
@@ -206,17 +214,17 @@ namespace Protogame
                     return true;
                 }
 
-                if (renderTarget.Format != GetRealBackBufferFormat(gameContext.Graphics.GraphicsDevice.PresentationParameters.BackBufferFormat))
+                if (renderTarget.Format != GetRealBackBufferFormat(renderContext.GraphicsDevice.PresentationParameters.BackBufferFormat))
                 {
                     return true;
                 }
 
-                if (renderTarget.DepthStencilFormat != gameContext.Graphics.GraphicsDevice.PresentationParameters.DepthStencilFormat)
+                if (renderTarget.DepthStencilFormat != renderContext.GraphicsDevice.PresentationParameters.DepthStencilFormat)
                 {
                     return true;
                 }
 
-                if (renderTarget.MultiSampleCount != gameContext.Graphics.GraphicsDevice.PresentationParameters.MultiSampleCount)
+                if (renderTarget.MultiSampleCount != renderContext.GraphicsDevice.PresentationParameters.MultiSampleCount)
                 {
                     return true;
                 }
@@ -225,7 +233,7 @@ namespace Protogame
             return false;
         }
 
-        public bool IsCustomRenderTargetOutOfDate(RenderTarget2D renderTarget, IGameContext gameContext, SurfaceFormat? surfaceFormat, DepthFormat? depthFormat, int? multiSampleCount)
+        public bool IsCustomRenderTargetOutOfDate(RenderTarget2D renderTarget, IRenderContext renderContext, SurfaceFormat? surfaceFormat, DepthFormat? depthFormat, int? multiSampleCount)
         {
             if (renderTarget == null)
             {
@@ -233,29 +241,29 @@ namespace Protogame
             }
             else
             {
-                var size = _backBufferDimensions.GetSize(gameContext.Graphics.GraphicsDevice);
+                var size = _backBufferDimensions.GetSize(renderContext.GraphicsDevice);
 
-                if (renderTarget.Width != size.X)
+                if (renderTarget.Width != size.Width)
                 {
                     return true;
                 }
 
-                if (renderTarget.Height != size.Y)
+                if (renderTarget.Height != size.Height)
                 {
                     return true;
                 }
 
-                if (renderTarget.Format != (surfaceFormat ?? GetRealBackBufferFormat(gameContext.Graphics.GraphicsDevice.PresentationParameters.BackBufferFormat)))
+                if (renderTarget.Format != (surfaceFormat ?? GetRealBackBufferFormat(renderContext.GraphicsDevice.PresentationParameters.BackBufferFormat)))
                 {
                     return true;
                 }
 
-                if (renderTarget.DepthStencilFormat != (depthFormat ?? gameContext.Graphics.GraphicsDevice.PresentationParameters.DepthStencilFormat))
+                if (renderTarget.DepthStencilFormat != (depthFormat ?? renderContext.GraphicsDevice.PresentationParameters.DepthStencilFormat))
                 {
                     return true;
                 }
 
-                if (renderTarget.MultiSampleCount != (multiSampleCount ?? gameContext.Graphics.GraphicsDevice.PresentationParameters.MultiSampleCount))
+                if (renderTarget.MultiSampleCount != (multiSampleCount ?? renderContext.GraphicsDevice.PresentationParameters.MultiSampleCount))
                 {
                     return true;
                 }
@@ -264,7 +272,7 @@ namespace Protogame
             return false;
         }
 
-        public bool IsCustomSizedRenderTargetOutOfDate(RenderTarget2D renderTarget, IGameContext gameContext, Vector2 size, SurfaceFormat? surfaceFormat, DepthFormat? depthFormat, int? multiSampleCount)
+        public bool IsCustomSizedRenderTargetOutOfDate(RenderTarget2D renderTarget, IRenderContext renderContext, Vector2 size, SurfaceFormat? surfaceFormat, DepthFormat? depthFormat, int? multiSampleCount)
         {
             if (renderTarget == null)
             {
@@ -282,17 +290,17 @@ namespace Protogame
                     return true;
                 }
 
-                if (renderTarget.Format != (surfaceFormat ?? GetRealBackBufferFormat(gameContext.Graphics.GraphicsDevice.PresentationParameters.BackBufferFormat)))
+                if (renderTarget.Format != (surfaceFormat ?? GetRealBackBufferFormat(renderContext.GraphicsDevice.PresentationParameters.BackBufferFormat)))
                 {
                     return true;
                 }
 
-                if (renderTarget.DepthStencilFormat != (depthFormat ?? gameContext.Graphics.GraphicsDevice.PresentationParameters.DepthStencilFormat))
+                if (renderTarget.DepthStencilFormat != (depthFormat ?? renderContext.GraphicsDevice.PresentationParameters.DepthStencilFormat))
                 {
                     return true;
                 }
 
-                if (renderTarget.MultiSampleCount != (multiSampleCount ?? gameContext.Graphics.GraphicsDevice.PresentationParameters.MultiSampleCount))
+                if (renderTarget.MultiSampleCount != (multiSampleCount ?? renderContext.GraphicsDevice.PresentationParameters.MultiSampleCount))
                 {
                     return true;
                 }

--- a/Protogame/Graphics/Effect/ScreenDimensionsEffectSemantic.cs
+++ b/Protogame/Graphics/Effect/ScreenDimensionsEffectSemantic.cs
@@ -55,8 +55,8 @@ namespace Protogame
         {
             var size = _backBufferDimensions.GetSize(renderContext.GraphicsDevice);
 
-            var width = size.X;
-            var height = size.Y;
+            var width = size.Width;
+            var height = size.Height;
 
             var needsUpdate = false;
             if (_lastScreenX != width)

--- a/Protogame/Graphics/IRenderTargetBackBufferUtilities.cs
+++ b/Protogame/Graphics/IRenderTargetBackBufferUtilities.cs
@@ -16,9 +16,9 @@ namespace Protogame
         /// one so that the returned render target matches the backbuffer.
         /// </summary>
         /// <param name="renderTarget">The existing render target, which is either returned or disposed.</param>
-        /// <param name="gameContext">The current game context.</param>
+        /// <param name="renderContext">The current render context.</param>
         /// <returns>A render target that matches the backbuffer.</returns>
-        RenderTarget2D UpdateRenderTarget(RenderTarget2D renderTarget, IGameContext gameContext);
+        RenderTarget2D UpdateRenderTarget(RenderTarget2D renderTarget, IRenderContext renderContext);
 
         /// <summary>
         /// Given an existing (or null) render target, returns either the existing
@@ -27,12 +27,12 @@ namespace Protogame
         /// a custom surface format and no depth buffer.
         /// </summary>
         /// <param name="renderTarget">The existing render target, which is either returned or disposed.</param>
-        /// <param name="gameContext">The current game context.</param>
+        /// <param name="renderContext">The current render context.</param>
         /// <param name="surfaceFormat">The surface format to use.</param>
         /// <param name="depthFormat"></param>
         /// <param name="multiSampleCount"></param>
         /// <returns>A render target that matches the backbuffer in size.</returns>
-        RenderTarget2D UpdateCustomRenderTarget(RenderTarget2D renderTarget, IGameContext gameContext, SurfaceFormat? surfaceFormat, DepthFormat? depthFormat, int? multiSampleCount);
+        RenderTarget2D UpdateCustomRenderTarget(RenderTarget2D renderTarget, IRenderContext renderContext, SurfaceFormat? surfaceFormat, DepthFormat? depthFormat, int? multiSampleCount);
 
         /// <summary>
         /// Given an existing (or null) render target, returns either the existing
@@ -40,10 +40,10 @@ namespace Protogame
         /// one so that the returned render target matches the specified size and backbuffer.
         /// </summary>
         /// <param name="renderTarget">The existing render target, which is either returned or disposed.</param>
-        /// <param name="gameContext">The current game context.</param>
+        /// <param name="renderContext">The current render context.</param>
         /// <param name="size">The size of the render target.</param>
         /// <returns>A render target that matches the backbuffer.</returns>
-        RenderTarget2D UpdateSizedRenderTarget(RenderTarget2D renderTarget, IGameContext gameContext, Vector2 size);
+        RenderTarget2D UpdateSizedRenderTarget(RenderTarget2D renderTarget, IRenderContext renderContext, Vector2 size);
 
         /// <summary>
         /// Given an existing (or null) render target, returns either the existing
@@ -53,51 +53,52 @@ namespace Protogame
         /// </summary>
         /// <param name="renderTarget">The existing render target, which is either returned or disposed.</param>
         /// <param name="size">The size of the render target.</param>
-        /// <param name="gameContext">The current game context.</param>
+        /// <param name="renderContext">The current render context.</param>
         /// <param name="surfaceFormat">The surface format to use.</param>
         /// <param name="depthFormat"></param>
         /// <param name="multiSampleCount"></param>
+        /// <param name="shared">If the render target should be shared.</param>
         /// <returns>A render target that matches the backbuffer in size.</returns>
-        RenderTarget2D UpdateCustomSizedRenderTarget(RenderTarget2D renderTarget, IGameContext gameContext, Vector2 size, SurfaceFormat? surfaceFormat, DepthFormat? depthFormat, int? multiSampleCount);
+        RenderTarget2D UpdateCustomSizedRenderTarget(RenderTarget2D renderTarget, IRenderContext renderContext, Vector2 size, SurfaceFormat? surfaceFormat, DepthFormat? depthFormat, int? multiSampleCount, bool? shared);
 
         /// <summary>
         /// Returns whether the specified render target matches the backbuffer.
         /// </summary>
         /// <param name="renderTarget">The render target to check.</param>
-        /// <param name="gameContext">The current game context.</param>
+        /// <param name="renderContext">The current render context.</param>
         /// <returns>Whether the specified render target matches the backbuffer.</returns>
-        bool IsRenderTargetOutOfDate(RenderTarget2D renderTarget, IGameContext gameContext);
+        bool IsRenderTargetOutOfDate(RenderTarget2D renderTarget, IRenderContext renderContext);
 
         /// <summary>
         /// Returns whether the specified render target matches the backbuffer and size.
         /// </summary>
         /// <param name="renderTarget">The render target to check.</param>
-        /// <param name="gameContext">The current game context.</param>
+        /// <param name="renderContext">The current render context.</param>
         /// <param name="size">The size of the render target.</param>
         /// <returns>Whether the specified render target matches the backbuffer.</returns>
-        bool IsSizedRenderTargetOutOfDate(RenderTarget2D renderTarget, IGameContext gameContext, Vector2 size);
+        bool IsSizedRenderTargetOutOfDate(RenderTarget2D renderTarget, IRenderContext renderContext, Vector2 size);
 
         /// <summary>
         /// Returns whether the specified custom render target matches the backbuffer size and specified surface format.
         /// </summary>
         /// <param name="renderTarget">The render target to check.</param>
-        /// <param name="gameContext">The current game context.</param>
+        /// <param name="renderContext">The current render context.</param>
         /// <param name="surfaceFormat">The surface format to use.</param>
         /// <param name="depthFormat"></param>
         /// <param name="multiSampleCount"></param>
         /// <returns>Whether the specified render target matches the backbuffer size and specified surface format.</returns>
-        bool IsCustomRenderTargetOutOfDate(RenderTarget2D renderTarget, IGameContext gameContext, SurfaceFormat? surfaceFormat, DepthFormat? depthFormat, int? multiSampleCount);
+        bool IsCustomRenderTargetOutOfDate(RenderTarget2D renderTarget, IRenderContext renderContext, SurfaceFormat? surfaceFormat, DepthFormat? depthFormat, int? multiSampleCount);
 
         /// <summary>
         /// Returns whether the specified custom render target matches the specified size and specified surface format.
         /// </summary>
         /// <param name="renderTarget">The render target to check.</param>
-        /// <param name="gameContext">The current game context.</param>
+        /// <param name="renderContext">The current render context.</param>
         /// <param name="size">The size of the render target.</param>
         /// <param name="surfaceFormat">The surface format to use.</param>
         /// <param name="depthFormat"></param>
         /// <param name="multiSampleCount"></param>
         /// <returns>Whether the specified render target matches the backbuffer size and specified surface format.</returns>
-        bool IsCustomSizedRenderTargetOutOfDate(RenderTarget2D renderTarget, IGameContext gameContext, Vector2 size, SurfaceFormat? surfaceFormat, DepthFormat? depthFormat, int? multiSampleCount);
+        bool IsCustomSizedRenderTargetOutOfDate(RenderTarget2D renderTarget, IRenderContext renderContext, Vector2 size, SurfaceFormat? surfaceFormat, DepthFormat? depthFormat, int? multiSampleCount);
     }
 }

--- a/Protogame/Graphics/RenderPipelineRenderContext.cs
+++ b/Protogame/Graphics/RenderPipelineRenderContext.cs
@@ -315,16 +315,16 @@ namespace Protogame
         /// </param>
         public void Render(IGameContext context)
         {
-            this.GraphicsDevice = context.Graphics.GraphicsDevice;
+            this.GraphicsDevice = context.Game.GraphicsDevice;
 
             if (this.SpriteBatch == null)
             {
-                this.SpriteBatch = new SpriteBatch(context.Graphics.GraphicsDevice);
+                this.SpriteBatch = new SpriteBatch(context.Game.GraphicsDevice);
             }
 
             if (this.SingleWhitePixel == null)
             {
-                this.SingleWhitePixel = new Texture2D(context.Graphics.GraphicsDevice, 1, 1, false, SurfaceFormat.Color);
+                this.SingleWhitePixel = new Texture2D(context.Game.GraphicsDevice, 1, 1, false, SurfaceFormat.Color);
                 this.SingleWhitePixel.SetData(new[] { Color.White });
             }
 

--- a/Protogame/Platform/AndroidGameWindow.cs
+++ b/Protogame/Platform/AndroidGameWindow.cs
@@ -72,13 +72,14 @@ namespace Protogame
             }
         }
 
-        /// <summary>
-        /// The underlying MonoGame window object.  The type and presence of this property
-        /// varies per-platform, so it's access should always be within a platform specific block.
-        /// </summary>
-        public AndroidMonoGameWindow PlatformWindow
+        public bool IsFullscreen => true;
+
+        public void SetFullscreen(bool fullscreen)
         {
-            get { return this.m_GameWindow; }
+        }
+
+        public void Resize(int width, int height)
+        {
         }
 
         public void SetCursorPosition(int x, int y)

--- a/Protogame/Platform/DefaultGameWindow.cs
+++ b/Protogame/Platform/DefaultGameWindow.cs
@@ -1,5 +1,6 @@
 #pragma warning disable CS1591
 
+using System;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Input;
 
@@ -12,9 +13,10 @@ namespace Protogame
     /// </summary>
     public class DefaultGameWindow : IGameWindow
     {
+        private readonly HostGame _hostGame;
         private readonly GameWindow _gameWindow;
 
-        public DefaultGameWindow(GameWindow gameWindow)
+        public DefaultGameWindow(HostGame hostGame, GameWindow gameWindow)
         {
             _gameWindow = gameWindow;
         }
@@ -57,10 +59,21 @@ namespace Protogame
                 }
             }
         }
-        
-        public GameWindow PlatformWindow
+
+        public bool IsFullscreen => _hostGame.GraphicsDeviceManager.IsFullScreen;
+
+        public void Resize(int width, int height)
         {
-            get { return _gameWindow; }
+            _hostGame.GraphicsDeviceManager.PreferredBackBufferWidth = width;
+            _hostGame.GraphicsDeviceManager.PreferredBackBufferHeight = height;
+            _hostGame.GraphicsDeviceManager.ApplyChanges();
+        }
+
+        public void SetFullscreen(bool fullscreen)
+        {
+            _hostGame.GraphicsDeviceManager.HardwareModeSwitch = false;
+            _hostGame.GraphicsDeviceManager.IsFullScreen = fullscreen;
+            _hostGame.GraphicsDeviceManager.ApplyChanges();
         }
 
         public void SetCursorPosition(int x, int y)

--- a/Protogame/Profiling/DefaultProfilerRenderPass.cs
+++ b/Protogame/Profiling/DefaultProfilerRenderPass.cs
@@ -63,9 +63,9 @@ namespace Protogame
 
             foreach (var visualiser in Visualisers)
             {
-                var height = visualiser.GetHeight(size.Y);
+                var height = visualiser.GetHeight(size.Height);
                 var rect = new Rectangle(
-                    Position == ProfilerPosition.TopLeft ? 0 : (size.X - 300),
+                    Position == ProfilerPosition.TopLeft ? 0 : (size.Width - 300),
                     y,
                     300,
                     height);


### PR DESCRIPTION
Previously we provided GraphicsDeviceManager on ICoreGame and IGameContext.  However, this service is not available if the underlying host is not derived from MonoGame's Game class, for example in the situation where Protogame is being embedded inside another application (like the editor).

In addition, we also provided MonoGame's GameWindow (or platform specific variant) on ICoreGame and IHostGame.  This is also not available if the game is not running from MonoGame's Game class.

This commit removes these properties in common API areas, so that developers won't accidentally use them without knowing that they can sometimes be null.  They are still available with some casting required:

- GraphicsDeviceManager is available from `((HostGame)gameContext.Game.HostGame).GraphicsDeviceManager`
- GameWindow is available from `((Game)gameContext.Game.HostGame).Window`

Note that these casts will fail if the HostGame is not the correct implementation which makes these instances available.

This commit also changes IRenderTargetBackBufferUtilities to accept IRenderContext instead of IGameContext.  This API should never have accepted IGameContext since it deals strictly with rendering, but it was possible for `GraphicsDevice` to be accessed via `gameContext.Graphics.GraphicsDevice`.  Since the GraphicsDeviceManager is no longer available in IGameContext, this API had to be updated to use the GraphicsDevice provided on IRenderContext. (Note that it's still possible to access the GraphicsDevice from IGameContext via the Game property, but this API needed cleaning up anyway.)

Internally a bunch of platform-specific window resize detection and handling has been moved from CoreGame into HostGame and internal references to GraphicsDeviceManager have been removed or replaced with the correct API usage.  IGameWindow now has a Resize method which is used to resize the window on platforms that support it, though developers should prefer the ResizeWindow method on IGameContext as that method also checks whether it's a valid time to perform the resize.