### PR TITLE
Add SetCursorPosition to IGameWindow

### DIFF
--- a/Protogame/Component/Builtin/FirstPersonControllerInputComponent.cs
+++ b/Protogame/Component/Builtin/FirstPersonControllerInputComponent.cs
@@ -104,7 +104,7 @@ namespace Protogame
                 var limit = MathHelper.PiOver2 - MathHelper.ToRadians(5);
                 _firstPersonCameraComponent.Pitch = MathHelper.Clamp(_firstPersonCameraComponent.Pitch, -limit, limit);
                 
-                Mouse.SetPosition(centerX, centerY);
+                gameContext.Window.SetCursorPosition(centerX, centerY);
 
                 return true;
             }

--- a/Protogame/Component/Builtin/FlyAroundInputComponent.cs
+++ b/Protogame/Component/Builtin/FlyAroundInputComponent.cs
@@ -69,7 +69,7 @@ namespace Protogame
                 var limit = MathHelper.PiOver2 - MathHelper.ToRadians(5);
                 _firstPersonCameraComponent.Pitch = MathHelper.Clamp(_firstPersonCameraComponent.Pitch, -limit, limit);
                 
-                Mouse.SetPosition(centerX, centerY);
+                gameContext.Window.SetCursorPosition(centerX, centerY);
 
                 return true;
             }

--- a/Protogame/Core/IGameWindow.cs
+++ b/Protogame/Core/IGameWindow.cs
@@ -43,6 +43,13 @@ namespace Protogame
         Microsoft.Xna.Framework.AndroidGameWindow PlatformWindow { get; }
 #endif
 
+        /// <summary>
+        /// Sets the position of the mouse cursor on the screen, relative to the window.
+        /// </summary>
+        /// <param name="x">The horizontal position of the cursor.</param>
+        /// <param name="y">The vertical position of the cursor.</param>
+        void SetCursorPosition(int x, int y);
+
 #if PLATFORM_WINDOWS
         void Maximize();
 

--- a/Protogame/Platform/AndroidGameWindow.cs
+++ b/Protogame/Platform/AndroidGameWindow.cs
@@ -80,6 +80,10 @@ namespace Protogame
         {
             get { return this.m_GameWindow; }
         }
+
+        public void SetCursorPosition(int x, int y)
+        {
+        }
     }
 }
 #endif

--- a/Protogame/Platform/DefaultGameWindow.cs
+++ b/Protogame/Platform/DefaultGameWindow.cs
@@ -1,6 +1,7 @@
 #pragma warning disable CS1591
 
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Input;
 
 #if PLATFORM_WINDOWS || PLATFORM_MACOS || PLATFORM_LINUX || PLATFORM_WEB || PLATFORM_IOS
 
@@ -60,6 +61,11 @@ namespace Protogame
         public GameWindow PlatformWindow
         {
             get { return _gameWindow; }
+        }
+
+        public void SetCursorPosition(int x, int y)
+        {
+            Mouse.SetPosition(x, y);
         }
 
 #if PLATFORM_WINDOWS


### PR DESCRIPTION
Mouse.SetPosition is not suitable for all hosts (e.g. when the game is hosted in an editor)