### PR TITLE
Make Priority settable for on StaticEventBinders

### DIFF
--- a/Protogame/Events/StaticEventBinder.cs
+++ b/Protogame/Events/StaticEventBinder.cs
@@ -33,6 +33,7 @@ namespace Protogame
         protected StaticEventBinder()
         {
             this._bindings = new List<Func<TContext, IEventEngine<TContext>, Event, bool>>();
+            Priority = 100;
         }
         
         protected interface IBindable<TEvent>
@@ -124,13 +125,7 @@ namespace Protogame
         {
         }
         
-        public int Priority
-        {
-            get
-            {
-                return 100;
-            }
-        }
+        public int Priority { get; set; }
         
         public void Assign(IKernel kernel)
         {


### PR DESCRIPTION
The event engine has a concept of event binder priority, which it uses to determine what order the event binders should have when processing events.  This makes the Priority property settable for derived implementations of StaticEventBinder.