### PR TITLE
Breaking changes: Remove state properties from input events

### DIFF
--- a/Protogame/Component/Builtin/FirstPersonControllerInputComponent.cs
+++ b/Protogame/Component/Builtin/FirstPersonControllerInputComponent.cs
@@ -98,12 +98,12 @@ namespace Protogame
                 var centerX = gameContext.Window.ClientBounds.Width/2;
                 var centerY = gameContext.Window.ClientBounds.Height/2;
 
-                _firstPersonCameraComponent.Yaw += (centerX - mouseEvent.MouseState.X)/1000f;
-                _firstPersonCameraComponent.Pitch += (centerY - mouseEvent.MouseState.Y)/1000f;
+                _firstPersonCameraComponent.Yaw += (centerX - mouseEvent.X)/1000f;
+                _firstPersonCameraComponent.Pitch += (centerY - mouseEvent.Y)/1000f;
 
                 var limit = MathHelper.PiOver2 - MathHelper.ToRadians(5);
                 _firstPersonCameraComponent.Pitch = MathHelper.Clamp(_firstPersonCameraComponent.Pitch, -limit, limit);
-
+                
                 Mouse.SetPosition(centerX, centerY);
 
                 return true;

--- a/Protogame/Component/Builtin/FlyAroundInputComponent.cs
+++ b/Protogame/Component/Builtin/FlyAroundInputComponent.cs
@@ -63,12 +63,12 @@ namespace Protogame
                 var centerX = gameContext.Window.ClientBounds.Width/2;
                 var centerY = gameContext.Window.ClientBounds.Height/2;
 
-                _firstPersonCameraComponent.Yaw += (centerX - mouseEvent.MouseState.X)/1000f;
-                _firstPersonCameraComponent.Pitch += (centerY - mouseEvent.MouseState.Y)/1000f;
+                _firstPersonCameraComponent.Yaw += (centerX - mouseEvent.X)/1000f;
+                _firstPersonCameraComponent.Pitch += (centerY - mouseEvent.Y)/1000f;
 
                 var limit = MathHelper.PiOver2 - MathHelper.ToRadians(5);
                 _firstPersonCameraComponent.Pitch = MathHelper.Clamp(_firstPersonCameraComponent.Pitch, -limit, limit);
-
+                
                 Mouse.SetPosition(centerX, centerY);
 
                 return true;

--- a/Protogame/Console/ClientConsoleInput.cs
+++ b/Protogame/Console/ClientConsoleInput.cs
@@ -31,8 +31,8 @@ namespace Protogame
             }
 
             var state = Keyboard.GetState();
-
-            _keyboardStringReader.Process(state, gameContext.GameTime, this._inputBuffer);
+            
+            _keyboardStringReader.Process(state.GetPressedKeys(), gameContext.GameTime, this._inputBuffer);
             if (this._inputBuffer.ToString().LastIndexOf('`') != -1)
             {
                 this._inputBuffer.Remove(this._inputBuffer.ToString().LastIndexOf('`'), 1);

--- a/Protogame/Core/DefaultGameContext.cs
+++ b/Protogame/Core/DefaultGameContext.cs
@@ -137,7 +137,14 @@ namespace Protogame
 
             _nextWorldTask = _coroutine.Run(async () =>
             {
-                _nextWorld = await _kernel.GetAsync<T>((INode)null, (string)null, (string)null, new IInjectionAttribute[0], new IConstructorArgument[0], (Dictionary<Type, List<IMapping>>)null);
+                try
+                {
+                    _nextWorld = await _kernel.GetAsync<T>((INode)null, (string)null, (string)null, new IInjectionAttribute[0], new IConstructorArgument[0], (Dictionary<Type, List<IMapping>>)null);
+                }
+                catch (Exception e)
+                {
+                    throw;
+                }
             });
         }
 

--- a/Protogame/Core/DefaultKeyboardStringReader.cs
+++ b/Protogame/Core/DefaultKeyboardStringReader.cs
@@ -187,12 +187,12 @@ namespace Protogame
         /// <param name="text">
         /// The StringBuilder to be modified based on keyboard state.
         /// </param>
-        public void Process(KeyboardState keyboard, GameTime time, StringBuilder text)
+        public void Process(Keys[] pressedKeys, GameTime time, StringBuilder text)
         {
-            var keys = keyboard.GetPressedKeys();
+            var keys = pressedKeys;
 
             // check and see if shift is down, caps lock is on, and/or num lock is on
-            var shift = keyboard.IsKeyDown(Keys.LeftShift) || keyboard.IsKeyDown(Keys.RightShift);
+            var shift = pressedKeys.Contains(Keys.LeftShift) || pressedKeys.Contains(Keys.RightShift);
 
 #if PLATFORM_WINDOWS || PLATFORM_MACOS || PLATFORM_LINUX
             var capsLock = Control.IsKeyLocked(System.Windows.Forms.Keys.CapsLock);

--- a/Protogame/Core/IKeyboardStringReader.cs
+++ b/Protogame/Core/IKeyboardStringReader.cs
@@ -10,6 +10,6 @@ namespace Protogame
         
         int RepeatKeyInterval { get; set; }
         
-        void Process(KeyboardState keyboard, GameTime time, StringBuilder text);
+        void Process(Keys[] pressedKeys, GameTime time, StringBuilder text);
     }
 }

--- a/Protogame/Events/EventEngineHook.cs
+++ b/Protogame/Events/EventEngineHook.cs
@@ -247,18 +247,18 @@ namespace Protogame
             {
                 if (keyboardState.IsKeyDown(key))
                 {
-                    _eventEngine.Fire(gameContext, new KeyHeldEvent { Key = key, KeyboardState = keyboardState });
+                    _eventEngine.Fire(gameContext, new KeyHeldEvent(keyboardState) { Key = key });
                 }
 
                 var change = keyboardState.IsKeyChanged(this, key);
 
                 if (change == KeyState.Down)
                 {
-                    _eventEngine.Fire(gameContext, new KeyPressEvent { Key = key, KeyboardState = keyboardState });
+                    _eventEngine.Fire(gameContext, new KeyPressEvent(keyboardState) { Key = key });
                 }
                 else if (change == KeyState.Up)
                 {
-                    _eventEngine.Fire(gameContext, new KeyReleaseEvent { Key = key, KeyboardState = keyboardState });
+                    _eventEngine.Fire(gameContext, new KeyReleaseEvent(keyboardState) { Key = key });
                 }
             }
         }
@@ -286,55 +286,52 @@ namespace Protogame
             {
                 _eventEngine.Fire(
                     gameContext, 
-                    new MousePressEvent { Button = MouseButton.Left, MouseState = mouseState });
+                    new MousePressEvent(mouseState) { Button = MouseButton.Left });
             }
 
             if (middleChange == ButtonState.Pressed)
             {
                 _eventEngine.Fire(
                     gameContext, 
-                    new MousePressEvent { Button = MouseButton.Middle, MouseState = mouseState });
+                    new MousePressEvent(mouseState) { Button = MouseButton.Middle });
             }
 
             if (rightChange == ButtonState.Pressed)
             {
                 _eventEngine.Fire(
                     gameContext, 
-                    new MousePressEvent { Button = MouseButton.Right, MouseState = mouseState });
+                    new MousePressEvent(mouseState) { Button = MouseButton.Right });
             }
 
             if (leftChange == ButtonState.Released)
             {
                 _eventEngine.Fire(
                     gameContext,
-                    new MouseReleaseEvent { Button = MouseButton.Left, MouseState = mouseState });
+                    new MouseReleaseEvent(mouseState) { Button = MouseButton.Left });
             }
 
             if (middleChange == ButtonState.Released)
             {
                 _eventEngine.Fire(
                     gameContext,
-                    new MouseReleaseEvent { Button = MouseButton.Middle, MouseState = mouseState });
+                    new MouseReleaseEvent(mouseState) { Button = MouseButton.Middle });
             }
 
             if (rightChange == ButtonState.Released)
             {
                 _eventEngine.Fire(
                     gameContext,
-                    new MouseReleaseEvent { Button = MouseButton.Right, MouseState = mouseState });
+                    new MouseReleaseEvent(mouseState) { Button = MouseButton.Right });
             }
 
             if (mouseState.X != _lastMouseState.Value.X || mouseState.Y != _lastMouseState.Value.Y)
             {
                 _eventEngine.Fire(
                     gameContext, 
-                    new MouseMoveEvent
+                    new MouseMoveEvent(mouseState)
                     {
-                        X = mouseState.X, 
-                        Y = mouseState.Y, 
                         LastX = _lastMouseState.Value.X, 
-                        LastY = _lastMouseState.Value.Y, 
-                        MouseState = mouseState
+                        LastY = _lastMouseState.Value.Y,
                     });
             }
 
@@ -344,7 +341,7 @@ namespace Protogame
                 {
                     _eventEngine.Fire(
                         gameContext,
-                        new MouseScrollEvent { ScrollDelta = (_lastMouseState.Value.ScrollWheelValue - mouseState.ScrollWheelValue), MouseState = mouseState });
+                        new MouseScrollEvent(mouseState) { ScrollDelta = (_lastMouseState.Value.ScrollWheelValue - mouseState.ScrollWheelValue) });
                 }
             }
 

--- a/Protogame/Events/KeyHeldEvent.cs
+++ b/Protogame/Events/KeyHeldEvent.cs
@@ -1,18 +1,51 @@
+using Microsoft.Xna.Framework.Input;
+using System;
+
 namespace Protogame
 {
-    using Microsoft.Xna.Framework.Input;
-
     /// <summary>
-    /// The key held event.
+    /// Represents a keyboard key being held down for more than one frame.
     /// </summary>
+    /// <module>Events</module>
+    [Serializable]
     public class KeyHeldEvent : KeyboardEvent
     {
         /// <summary>
-        /// Gets or sets the key.
+        /// Constructs a new default <see cref="KeyHeldEvent"/>.
         /// </summary>
-        /// <value>
-        /// The key.
-        /// </value>
+        public KeyHeldEvent()
+        {
+        }
+
+        /// <summary>
+        /// Constructs a new <see cref="KeyHeldEvent"/> from a <see cref="KeyboardState"/>.
+        /// </summary>
+        /// <param name="state">The MonoGame representation of the keyboard.</param>
+        public KeyHeldEvent(KeyboardState state) : base(state)
+        {
+        }
+
+        /// <summary>
+        /// Constructs a new <see cref="KeyHeldEvent"/> from an existing <see cref="KeyHeldEvent"/>.
+        /// </summary>
+        /// <param name="keyboardEvent">The existing keyboard event.</param>
+        public KeyHeldEvent(KeyHeldEvent keyboardEvent) : base(keyboardEvent)
+        {
+            Key = keyboardEvent.Key;
+        }
+
+        /// <summary>
+        /// Clones the current keyboard event instance and returns a copy.
+        /// </summary>
+        /// <returns>A copy of the current keyboard event.</returns>
+        public override KeyboardEvent Clone()
+        {
+            return new KeyHeldEvent(this);
+        }
+
+        /// <summary>
+        /// The key that is being held down for more than one frame.
+        /// </summary>
         public Keys Key { get; set; }
     }
 }

--- a/Protogame/Events/KeyPressEvent.cs
+++ b/Protogame/Events/KeyPressEvent.cs
@@ -1,18 +1,51 @@
+using Microsoft.Xna.Framework.Input;
+using System;
+
 namespace Protogame
 {
-    using Microsoft.Xna.Framework.Input;
-
     /// <summary>
-    /// The key press event.
+    /// Represents a keyboard key being pressed down for the first frame.
     /// </summary>
+    /// <module>Events</module>
+    [Serializable]
     public class KeyPressEvent : KeyboardEvent
     {
         /// <summary>
-        /// Gets or sets the key.
+        /// Constructs a new default <see cref="KeyPressEvent"/>.
         /// </summary>
-        /// <value>
-        /// The key.
-        /// </value>
+        public KeyPressEvent()
+        {
+        }
+
+        /// <summary>
+        /// Constructs a new <see cref="KeyPressEvent"/> from a <see cref="KeyboardState"/>.
+        /// </summary>
+        /// <param name="state">The MonoGame representation of the keyboard.</param>
+        public KeyPressEvent(KeyboardState state) : base(state)
+        {
+        }
+
+        /// <summary>
+        /// Constructs a new <see cref="KeyPressEvent"/> from an existing <see cref="KeyPressEvent"/>.
+        /// </summary>
+        /// <param name="keyboardEvent">The existing keyboard event.</param>
+        public KeyPressEvent(KeyPressEvent keyboardEvent) : base(keyboardEvent)
+        {
+            Key = keyboardEvent.Key;
+        }
+
+        /// <summary>
+        /// Clones the current keyboard event instance and returns a copy.
+        /// </summary>
+        /// <returns>A copy of the current keyboard event.</returns>
+        public override KeyboardEvent Clone()
+        {
+            return new KeyPressEvent(this);
+        }
+
+        /// <summary>
+        /// The key being pressed down for the first frame.
+        /// </summary>
         public Keys Key { get; set; }
     }
 }

--- a/Protogame/Events/KeyReleaseEvent.cs
+++ b/Protogame/Events/KeyReleaseEvent.cs
@@ -1,18 +1,51 @@
+using Microsoft.Xna.Framework.Input;
+using System;
+
 namespace Protogame
 {
-    using Microsoft.Xna.Framework.Input;
-
     /// <summary>
-    /// The key press event.
+    /// Represents a keyboard key being released.
     /// </summary>
+    /// <module>Events</module>
+    [Serializable]
     public class KeyReleaseEvent : KeyboardEvent
     {
         /// <summary>
-        /// Gets or sets the key.
+        /// Constructs a new default <see cref="KeyReleaseEvent"/>.
         /// </summary>
-        /// <value>
-        /// The key.
-        /// </value>
+        public KeyReleaseEvent()
+        {
+        }
+
+        /// <summary>
+        /// Constructs a new <see cref="KeyReleaseEvent"/> from a <see cref="KeyboardState"/>.
+        /// </summary>
+        /// <param name="state">The MonoGame representation of the keyboard.</param>
+        public KeyReleaseEvent(KeyboardState state) : base(state)
+        {
+        }
+
+        /// <summary>
+        /// Constructs a new <see cref="KeyReleaseEvent"/> from an existing <see cref="KeyReleaseEvent"/>.
+        /// </summary>
+        /// <param name="keyboardEvent">The existing keyboard event.</param>
+        public KeyReleaseEvent(KeyReleaseEvent keyboardEvent) : base(keyboardEvent)
+        {
+            Key = keyboardEvent.Key;
+        }
+
+        /// <summary>
+        /// Clones the current keyboard event instance and returns a copy.
+        /// </summary>
+        /// <returns>A copy of the current keyboard event.</returns>
+        public override KeyboardEvent Clone()
+        {
+            return new KeyReleaseEvent(this);
+        }
+
+        /// <summary>
+        /// The key that was released.
+        /// </summary>
         public Keys Key { get; set; }
     }
 }

--- a/Protogame/Events/KeyboardEvent.cs
+++ b/Protogame/Events/KeyboardEvent.cs
@@ -1,18 +1,121 @@
+using Microsoft.Xna.Framework.Input;
+using System;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
 namespace Protogame
 {
-    using Microsoft.Xna.Framework.Input;
-
     /// <summary>
-    /// The keyboard event.
+    /// Represents a keyboard event.
     /// </summary>
+    /// <module>Events</module>
+    [Serializable]
     public class KeyboardEvent : Event
     {
+        [NonSerialized]
+        private HashSet<Keys> _pressedKeysHashSet;
+        private Keys[] _pressedKeysArray;
+
         /// <summary>
-        /// Gets or sets the keyboard state.
+        /// Constructs a new default <see cref="KeyboardEvent"/>.
         /// </summary>
-        /// <value>
-        /// The keyboard state.
-        /// </value>
-        public KeyboardState KeyboardState { get; set; }
+        public KeyboardEvent()
+        {
+            _pressedKeysArray = new Keys[0];
+            _pressedKeysHashSet = new HashSet<Keys>();
+        }
+        
+        /// <summary>
+        /// Constructs a new <see cref="KeyboardEvent"/> from a <see cref="KeyboardState"/>.
+        /// </summary>
+        /// <param name="state">The MonoGame representation of the keyboard.</param>
+        public KeyboardEvent(KeyboardState state)
+        {
+            CapsLock = state.CapsLock;
+            NumLock = state.NumLock;
+            PressedKeys = state.GetPressedKeys();
+        }
+
+        /// <summary>
+        /// Constructs a new <see cref="KeyboardEvent"/> from an existing <see cref="KeyboardEvent"/>.
+        /// </summary>
+        /// <param name="keyboardEvent">The existing keyboard event.</param>
+        public KeyboardEvent(KeyboardEvent keyboardEvent)
+        {
+            CapsLock = keyboardEvent.CapsLock;
+            NumLock = keyboardEvent.NumLock;
+            PressedKeys = keyboardEvent.PressedKeys;
+        }
+
+        /// <summary>
+        /// Clones the current keyboard event instance and returns a copy.
+        /// </summary>
+        /// <returns>A copy of the current keyboard event.</returns>
+        public virtual KeyboardEvent Clone()
+        {
+            return new KeyboardEvent(this);
+        }
+
+        [OnDeserialized]
+        internal void OnDeserialize(StreamingContext context)
+        {
+            _pressedKeysHashSet = new HashSet<Keys>(_pressedKeysArray);
+        }
+
+        /// <summary>
+        /// Whether or not Caps Lock is currently active.
+        /// </summary>
+        public bool CapsLock { get; set; }
+
+        /// <summary>
+        /// Whether or not Num Lock is currently active.
+        /// </summary>
+        public bool NumLock { get; set; }
+
+        /// <summary>
+        /// A list of keys that are currently being pressed.
+        /// </summary>
+        public Keys[] PressedKeys
+        {
+            get
+            {
+                return _pressedKeysArray;
+            }
+            set
+            {
+                _pressedKeysArray = value;
+                _pressedKeysHashSet = new HashSet<Keys>(_pressedKeysArray);
+            }
+        }
+
+        /// <summary>
+        /// Returns the state of the specified key.
+        /// </summary>
+        /// <param name="key">The key to check.</param>
+        /// <returns>The state of the key.</returns>
+        public KeyState this[Keys key]
+        {
+            get { return IsKeyDown(key) ? KeyState.Down : KeyState.Up; }
+        }
+
+        /// <summary>
+        /// Returns whether a key is currently being pressed down or held down.
+        /// </summary>
+        /// <param name="key">The key to check.</param>
+        /// <returns>True if the key is pressed, false otherwise.</returns>
+        public bool IsKeyDown(Keys key)
+        {
+            return _pressedKeysHashSet.Contains(key);
+        }
+
+        /// <summary>
+        /// Returns whether a key is not currently pressed.
+        /// </summary>
+        /// <param name="key">The key to check.</param>
+        /// <returns>True if the key is not pressed, false otherwise.</returns>
+        public bool IsKeyUp(Keys key)
+        {
+            return !_pressedKeysHashSet.Contains(key);
+        }
     }
 }

--- a/Protogame/Events/MouseButton.cs
+++ b/Protogame/Events/MouseButton.cs
@@ -1,22 +1,23 @@
 namespace Protogame
 {
     /// <summary>
-    /// The mouse button.
+    /// Represents a button on a mouse.
     /// </summary>
+    /// <module>Events</module>
     public enum MouseButton
     {
         /// <summary>
-        /// The left.
+        /// The left mouse button.
         /// </summary>
         Left, 
 
         /// <summary>
-        /// The right.
+        /// The right mouse button.
         /// </summary>
         Right, 
 
         /// <summary>
-        /// The middle.
+        /// The middle mouse button.
         /// </summary>
         Middle
     }

--- a/Protogame/Events/MouseEvent.cs
+++ b/Protogame/Events/MouseEvent.cs
@@ -1,18 +1,117 @@
+using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Input;
+using System;
+using System.Runtime.Serialization;
+
 namespace Protogame
 {
-    using Microsoft.Xna.Framework.Input;
-
     /// <summary>
-    /// The mouse event.
+    /// Represents a mouse event.
     /// </summary>
+    /// <module>Events</module>
+    [Serializable]
     public class MouseEvent : Event
     {
         /// <summary>
-        /// Gets or sets the mouse state.
+        /// Constructs a new default <see cref="MouseEvent"/>.
         /// </summary>
-        /// <value>
-        /// The mouse state.
-        /// </value>
-        public MouseState MouseState { get; set; }
+        public MouseEvent()
+        {
+        }
+
+        /// <summary>
+        /// Constructs a new <see cref="MouseEvent"/> from a <see cref="MouseState"/>.
+        /// </summary>
+        /// <param name="state">The MonoGame representation of the mouse.</param>
+        public MouseEvent(MouseState state)
+        {
+            X = state.X;
+            Y = state.Y;
+            LeftButton = state.LeftButton;
+            MiddleButton = state.MiddleButton;
+            RightButton = state.RightButton;
+            XButton1 = state.XButton1;
+            XButton2 = state.XButton2;
+        }
+
+        /// <summary>
+        /// Constructs a new <see cref="MouseEvent"/> from an existing <see cref="MouseEvent"/>.
+        /// </summary>
+        /// <param name="mouseEvent">The existing mouse event.</param>
+        public MouseEvent(MouseEvent mouseEvent)
+        {
+            X = mouseEvent.X;
+            Y = mouseEvent.Y;
+            LeftButton = mouseEvent.LeftButton;
+            MiddleButton = mouseEvent.MiddleButton;
+            RightButton = mouseEvent.RightButton;
+            XButton1 = mouseEvent.XButton1;
+            XButton2 = mouseEvent.XButton2;
+        }
+
+        /// <summary>
+        /// Clones the current mouse event instance and returns a copy.
+        /// </summary>
+        /// <returns>A copy of the current mouse event.</returns>
+        public virtual MouseEvent Clone()
+        {
+            return new MouseEvent(this);
+        }
+
+        /// <summary>
+        /// The horizontal position of the cursor in relation to the window.
+        /// </summary>
+        public int X { get; set; }
+
+        /// <summary>
+        /// The vertical position of the cursor in relation to the window.
+        /// </summary>
+        public int Y { get; set; }
+
+        /// <summary>
+        /// The cursor position in relation to the window.
+        /// </summary>
+        public Point Position => new Point(X, Y);
+
+        /// <summary>
+        /// Returns cumulative scroll wheel value since the game start.
+        /// </summary>
+        public int ScrollWheelValue { get; set; }
+
+        /// <summary>
+        /// The state of the left mouse button.
+        /// </summary>
+        public ButtonState LeftButton { get; set; }
+
+        /// <summary>
+        /// The state of the middle mouse button.
+        /// </summary>
+        public ButtonState MiddleButton { get; set; }
+
+        /// <summary>
+        /// The state of the right mouse button.
+        /// </summary>
+        public ButtonState RightButton { get; set; }
+
+        /// <summary>
+        /// The state of extra mouse button 1.
+        /// </summary>
+        public ButtonState XButton1 { get; set; }
+
+        /// <summary>
+        /// The state of extra mouse button 2.
+        /// </summary>
+        public ButtonState XButton2 { get; set; }
+
+        /// <summary>
+        /// The MonoGame mouse state.
+        /// </summary>
+        /// <remarks>
+        /// Calling this property will result in a new <see cref="MouseState"/> being
+        /// constructed.  You should use the members directly available on <see cref="MouseEvent"/>
+        /// instead of using this property.
+        /// </remarks>
+        [Obsolete("Use the MouseEvent members directly instead of MouseState.")]
+        public MouseState MouseState => new MouseState(X, Y, ScrollWheelValue, LeftButton, MiddleButton, RightButton, XButton1, XButton2);
     }
 }

--- a/Protogame/Events/MouseMoveEvent.cs
+++ b/Protogame/Events/MouseMoveEvent.cs
@@ -1,40 +1,57 @@
+using Microsoft.Xna.Framework.Input;
+using System;
+
 namespace Protogame
 {
     /// <summary>
-    /// The mouse move event.
+    /// Represents movement of the mouse cursor on the screen
     /// </summary>
+    /// <module>Events</module>
+    [Serializable]
     public class MouseMoveEvent : MouseEvent
     {
         /// <summary>
-        /// Gets or sets the last x.
+        /// Constructs a new default <see cref="MouseMoveEvent"/>.
         /// </summary>
-        /// <value>
-        /// The last x.
-        /// </value>
+        public MouseMoveEvent()
+        {
+        }
+
+        /// <summary>
+        /// Constructs a new <see cref="MouseMoveEvent"/> from a <see cref="MouseState"/>.
+        /// </summary>
+        /// <param name="state">The MonoGame representation of the mouse.</param>
+        public MouseMoveEvent(MouseState state) : base(state)
+        {
+        }
+
+        /// <summary>
+        /// Constructs a new <see cref="MouseMoveEvent"/> from an existing <see cref="MouseMoveEvent"/>.
+        /// </summary>
+        /// <param name="mouseEvent">The existing mouse move event.</param>
+        public MouseMoveEvent(MouseMoveEvent mouseEvent) : base(mouseEvent)
+        {
+            LastX = mouseEvent.LastX;
+            LastY = mouseEvent.LastY;
+        }
+
+        /// <summary>
+        /// Clones the current mouse event instance and returns a copy.
+        /// </summary>
+        /// <returns>A copy of the current mouse event.</returns>
+        public override MouseEvent Clone()
+        {
+            return new MouseMoveEvent(this);
+        }
+
+        /// <summary>
+        /// The previous horizontal position of the mouse cursor in relation to the window.
+        /// </summary>
         public int LastX { get; set; }
 
         /// <summary>
-        /// Gets or sets the last y.
+        /// The previous vertical position of the mouse cursor in relation to the window.
         /// </summary>
-        /// <value>
-        /// The last y.
-        /// </value>
         public int LastY { get; set; }
-
-        /// <summary>
-        /// Gets or sets the x.
-        /// </summary>
-        /// <value>
-        /// The x.
-        /// </value>
-        public int X { get; set; }
-
-        /// <summary>
-        /// Gets or sets the y.
-        /// </summary>
-        /// <value>
-        /// The y.
-        /// </value>
-        public int Y { get; set; }
     }
 }

--- a/Protogame/Events/MousePressEvent.cs
+++ b/Protogame/Events/MousePressEvent.cs
@@ -1,16 +1,51 @@
+using Microsoft.Xna.Framework.Input;
+using System;
+
 namespace Protogame
 {
     /// <summary>
-    /// The mouse press event.
+    /// Represents a button on a mouse being pressed down.
     /// </summary>
+    /// <module>Events</module>
+    [Serializable]
     public class MousePressEvent : MouseEvent
     {
         /// <summary>
-        /// Gets or sets the button.
+        /// Constructs a new default <see cref="MousePressEvent"/>.
         /// </summary>
-        /// <value>
-        /// The button.
-        /// </value>
+        public MousePressEvent()
+        {
+        }
+
+        /// <summary>
+        /// Constructs a new <see cref="MousePressEvent"/> from a <see cref="MouseState"/>.
+        /// </summary>
+        /// <param name="state">The MonoGame representation of the mouse.</param>
+        public MousePressEvent(MouseState state) : base(state)
+        {
+        }
+
+        /// <summary>
+        /// Constructs a new <see cref="MousePressEvent"/> from an existing <see cref="MousePressEvent"/>.
+        /// </summary>
+        /// <param name="mouseEvent">The existing mouse press event.</param>
+        public MousePressEvent(MousePressEvent mouseEvent) : base(mouseEvent)
+        {
+            Button = mouseEvent.Button;
+        }
+
+        /// <summary>
+        /// Clones the current mouse event instance and returns a copy.
+        /// </summary>
+        /// <returns>A copy of the current mouse event.</returns>
+        public override MouseEvent Clone()
+        {
+            return new MousePressEvent(this);
+        }
+        
+        /// <summary>
+        /// The button that was pressed down.
+        /// </summary>
         public MouseButton Button { get; set; }
     }
 }

--- a/Protogame/Events/MouseReleaseEvent.cs
+++ b/Protogame/Events/MouseReleaseEvent.cs
@@ -1,16 +1,51 @@
+using Microsoft.Xna.Framework.Input;
+using System;
+
 namespace Protogame
 {
     /// <summary>
-    /// The mouse release event.
+    /// Represents a button on a mouse being released.
     /// </summary>
+    /// <module>Events</module>
+    [Serializable]
     public class MouseReleaseEvent : MouseEvent
     {
         /// <summary>
-        /// Gets or sets the button.
+        /// Constructs a new default <see cref="MouseReleaseEvent"/>.
         /// </summary>
-        /// <value>
-        /// The button.
-        /// </value>
+        public MouseReleaseEvent()
+        {
+        }
+
+        /// <summary>
+        /// Constructs a new <see cref="MouseReleaseEvent"/> from a <see cref="MouseState"/>.
+        /// </summary>
+        /// <param name="state">The MonoGame representation of the mouse.</param>
+        public MouseReleaseEvent(MouseState state) : base(state)
+        {
+        }
+
+        /// <summary>
+        /// Constructs a new <see cref="MouseReleaseEvent"/> from an existing <see cref="MouseReleaseEvent"/>.
+        /// </summary>
+        /// <param name="mouseEvent">The existing mouse release event.</param>
+        public MouseReleaseEvent(MouseReleaseEvent mouseEvent) : base(mouseEvent)
+        {
+            Button = mouseEvent.Button;
+        }
+
+        /// <summary>
+        /// Clones the current mouse event instance and returns a copy.
+        /// </summary>
+        /// <returns>A copy of the current mouse event.</returns>
+        public override MouseEvent Clone()
+        {
+            return new MouseReleaseEvent(this);
+        }
+
+        /// <summary>
+        /// The mouse button that was released.
+        /// </summary>
         public MouseButton Button { get; set; }
     }
 }

--- a/Protogame/Events/MouseScrollEvent.cs
+++ b/Protogame/Events/MouseScrollEvent.cs
@@ -1,10 +1,48 @@
+using Microsoft.Xna.Framework.Input;
+using System;
+
 namespace Protogame
 {
     /// <summary>
-    /// Fired when the mouse wheel is scrolled.
+    /// Represents the mouse wheel being scrolled.
     /// </summary>
+    /// <module>Events</module>
+    [Serializable]
     public class MouseScrollEvent : MouseEvent
     {
+        /// <summary>
+        /// Constructs a new default <see cref="MouseScrollEvent"/>.
+        /// </summary>
+        public MouseScrollEvent()
+        {
+        }
+
+        /// <summary>
+        /// Constructs a new <see cref="MouseScrollEvent"/> from a <see cref="MouseState"/>.
+        /// </summary>
+        /// <param name="state">The MonoGame representation of the mouse.</param>
+        public MouseScrollEvent(MouseState state) : base(state)
+        {
+        }
+
+        /// <summary>
+        /// Constructs a new <see cref="MouseScrollEvent"/> from an existing <see cref="MouseScrollEvent"/>.
+        /// </summary>
+        /// <param name="mouseEvent">The existing mouse release event.</param>
+        public MouseScrollEvent(MouseScrollEvent mouseEvent) : base(mouseEvent)
+        {
+            ScrollDelta = mouseEvent.ScrollDelta;
+        }
+
+        /// <summary>
+        /// Clones the current mouse event instance and returns a copy.
+        /// </summary>
+        /// <returns>A copy of the current mouse event.</returns>
+        public override MouseEvent Clone()
+        {
+            return new MouseScrollEvent(this);
+        }
+
         /// <summary>
         /// The amount the mouse wheel has scrolled by.
         /// </summary>

--- a/Protogame/Server/NullKeyboardStringReader.cs
+++ b/Protogame/Server/NullKeyboardStringReader.cs
@@ -9,7 +9,7 @@ namespace Protogame
     {
         public int FirstRepeatKeyInterval { get; set; }
         public int RepeatKeyInterval { get; set; }
-        public void Process(KeyboardState keyboard, GameTime time, StringBuilder text)
+        public void Process(Keys[] pressedKeys, GameTime time, StringBuilder text)
         {
             throw new NotSupportedException();
         }

--- a/Protogame/UserInterface/Control/Button.cs
+++ b/Protogame/UserInterface/Control/Button.cs
@@ -63,8 +63,8 @@ namespace Protogame
 
             if (mouseEvent != null)
             {
-                x = mouseEvent.MouseState.X;
-                y = mouseEvent.MouseState.Y;
+                x = mouseEvent.X;
+                y = mouseEvent.Y;
             }
 
             if (touchPressEvent != null)

--- a/Protogame/UserInterface/Control/CheckBox.cs
+++ b/Protogame/UserInterface/Control/CheckBox.cs
@@ -54,8 +54,8 @@ namespace Protogame
 
             if (mouseEvent != null)
             {
-                x = mouseEvent.MouseState.X;
-                y = mouseEvent.MouseState.Y;
+                x = mouseEvent.X;
+                y = mouseEvent.Y;
             }
 
             if (layout.Contains(x, y))

--- a/Protogame/UserInterface/Control/Container/ScrollableContainer.cs
+++ b/Protogame/UserInterface/Control/Container/ScrollableContainer.cs
@@ -284,25 +284,25 @@ namespace Protogame
                
                 if (mousePressEvent != null && mousePressEvent.Button == MouseButton.Left)
                 {
-                    if (horizontalScrollBarRectangle.Contains(mousePressEvent.MouseState.Position))
+                    if (horizontalScrollBarRectangle.Contains(mousePressEvent.Position))
                     {
                         if (ChildWidth > layout.Width)
                         {
                             _isHorizontalScrolling = true;
-                            _horizontalScrollOffset = mousePressEvent.MouseState.Position.X - horizontalScrollBarRectangle.X;
-                            _horizontalScrollStart = mousePressEvent.MouseState.Position.X;
+                            _horizontalScrollOffset = mousePressEvent.X - horizontalScrollBarRectangle.X;
+                            _horizontalScrollStart = mousePressEvent.X;
                         }
 
                         return true;
                     }
 
-                    if (verticalScrollBarRectangle.Contains(mousePressEvent.MouseState.Position))
+                    if (verticalScrollBarRectangle.Contains(mousePressEvent.Position))
                     {
                         if (ChildHeight > layout.Height)
                         {
                             _isVerticalScrolling = true;
-                            _verticalScrollOffset = mousePressEvent.MouseState.Position.Y - verticalScrollBarRectangle.Y;
-                            _verticalScrollStart = mousePressEvent.MouseState.Position.Y;
+                            _verticalScrollOffset = mousePressEvent.Y - verticalScrollBarRectangle.Y;
+                            _verticalScrollStart = mousePressEvent.Y;
                         }
 
                         return true;
@@ -323,16 +323,8 @@ namespace Protogame
                     scrollXPixels = (int)(ScrollX * (Math.Max(ChildWidth, layoutWidth) - layoutWidth));
                     scrollYPixels = (int)(ScrollY * (Math.Max(ChildHeight, layoutHeight) - layoutHeight));
 
-                    originalState = mouseEvent.MouseState;
-                    mouseEvent.MouseState = new MouseState(
-                        mouseEvent.MouseState.X + scrollXPixels,
-                        mouseEvent.MouseState.Y + scrollYPixels,
-                        mouseEvent.MouseState.ScrollWheelValue,
-                        mouseEvent.MouseState.LeftButton,
-                        mouseEvent.MouseState.MiddleButton,
-                        mouseEvent.MouseState.RightButton,
-                        mouseEvent.MouseState.XButton1,
-                        mouseEvent.MouseState.XButton2);
+                    mouseEvent.X += scrollXPixels;
+                    mouseEvent.Y += scrollYPixels;
 
                     var mouseMoveEvent = @event as MouseMoveEvent;
 
@@ -354,7 +346,8 @@ namespace Protogame
                 // Restore event state.
                 if (mouseEvent != null)
                 {
-                    mouseEvent.MouseState = originalState;
+                    mouseEvent.X -= scrollXPixels;
+                    mouseEvent.Y -= scrollYPixels;
 
                     var mouseMoveEvent = @event as MouseMoveEvent;
 

--- a/Protogame/UserInterface/Control/Container/SingleContainer.cs
+++ b/Protogame/UserInterface/Control/Container/SingleContainer.cs
@@ -58,7 +58,7 @@ namespace Protogame
             _child?.Update(skinLayout, GetChildLayout(layout, skinLayout), gameTime, ref stealFocus);
         }
         
-        public bool HandleEvent(ISkinLayout skinLayout, Rectangle layout, IGameContext context, Event @event)
+        public virtual bool HandleEvent(ISkinLayout skinLayout, Rectangle layout, IGameContext context, Event @event)
         {
             return _child != null && _child.HandleEvent(skinLayout, GetChildLayout(layout, skinLayout), context, @event);
         }

--- a/Protogame/UserInterface/Control/FileSelect.cs
+++ b/Protogame/UserInterface/Control/FileSelect.cs
@@ -50,7 +50,7 @@ namespace Protogame
                 return false;
             }
 
-            if (layout.Contains(mouseEvent.MouseState.X, mouseEvent.MouseState.Y))
+            if (layout.Contains(mouseEvent.X, mouseEvent.Y))
             {
                 if (mouseMoveEvent != null)
                 {

--- a/Protogame/UserInterface/Control/Link.cs
+++ b/Protogame/UserInterface/Control/Link.cs
@@ -40,7 +40,7 @@ namespace Protogame
             var mousePressEvent = @event as MousePressEvent;
             if (mousePressEvent != null)
             {
-                if (!layout.Contains(mousePressEvent.MouseState.X, mousePressEvent.MouseState.Y))
+                if (!layout.Contains(mousePressEvent.X, mousePressEvent.Y))
                 {
                     return false;
                 }
@@ -55,7 +55,7 @@ namespace Protogame
             var mouseReleaseEvent = @event as MouseReleaseEvent;
             if (mouseReleaseEvent != null)
             {
-                if (!layout.Contains(mouseReleaseEvent.MouseState.X, mouseReleaseEvent.MouseState.Y))
+                if (!layout.Contains(mouseReleaseEvent.X, mouseReleaseEvent.Y))
                 {
                     return false;
                 }

--- a/Protogame/UserInterface/Control/ListItem.cs
+++ b/Protogame/UserInterface/Control/ListItem.cs
@@ -36,7 +36,7 @@ namespace Protogame
             {
                 return false;
             }
-            if (!layout.Contains(mouseEvent.MouseState.X, mouseEvent.MouseState.Y))
+            if (!layout.Contains(mouseEvent.X, mouseEvent.Y))
             {
                 return false;
             }

--- a/Protogame/UserInterface/Control/TextBox.cs
+++ b/Protogame/UserInterface/Control/TextBox.cs
@@ -68,7 +68,7 @@ namespace Protogame
 
             if (mousePressEvent != null && mousePressEvent.Button == MouseButton.Left)
             {
-                if (layout.Contains(mousePressEvent.MouseState.X, mousePressEvent.MouseState.Y))
+                if (layout.Contains(mousePressEvent.X, mousePressEvent.Y))
                 {
                     this.Focus();
 
@@ -102,10 +102,9 @@ namespace Protogame
 
             if (keyEvent != null)
             {
-                var keyboard = keyEvent.KeyboardState;
                 if (Focused)
                 {
-                    _keyboardReader.Process(keyboard, context.GameTime, _textBuilder);
+                    _keyboardReader.Process(keyEvent.PressedKeys, context.GameTime, _textBuilder);
                     if (_textBuilder.ToString() != _previousValue)
                     {
                         TextChanged?.Invoke(this, new EventArgs());

--- a/Protogame/UserInterface/Control/TreeItem.cs
+++ b/Protogame/UserInterface/Control/TreeItem.cs
@@ -35,7 +35,7 @@ namespace Protogame
                 return false;
             }
 
-            if (!layout.Contains(mouseEvent.MouseState.X, mouseEvent.MouseState.Y))
+            if (!layout.Contains(mouseEvent.X, mouseEvent.Y))
             {
                 return false;
             }


### PR DESCRIPTION
The `MouseState` and `KeyboardState` classes are not serializable across appdomain boundaries, and for the upcoming Protogame editor, we need to be able to forward events from the editor's appdomain to the game's appdomain.

While theoretically we could reconstruct the MouseState and KeyboardState on the receiving side, it makes more architectural sense to just remove the dependency on MonoGame classes here, and provide all the information on the event classes themselves.

If you are upgrading past this change, remove the `.MouseState` access on any mouse event; all mouse state properties are now on the event directly.  For KeyboardState you should do the same, though `GetPressedKeys` is now just the `PressedKeys` property.