### PR TITLE
Make BeginRenderPass / EndRenderPass virtual for canvas render pass

### DIFF
--- a/Protogame/Graphics/DefaultCanvasRenderPass.cs
+++ b/Protogame/Graphics/DefaultCanvasRenderPass.cs
@@ -36,7 +36,7 @@ namespace Protogame
             set;
         }
 
-        public void BeginRenderPass(IGameContext gameContext, IRenderContext renderContext, IRenderPass previousPass, RenderTarget2D postProcessingSource)
+        public virtual void BeginRenderPass(IGameContext gameContext, IRenderContext renderContext, IRenderPass previousPass, RenderTarget2D postProcessingSource)
         {
             if (Viewport != null)
             {
@@ -69,7 +69,7 @@ namespace Protogame
             renderContext.SpriteBatch.Begin(TextureSortMode);
         }
 
-        public void EndRenderPass(IGameContext gameContext, IRenderContext renderContext, IRenderPass nextPass)
+        public virtual void EndRenderPass(IGameContext gameContext, IRenderContext renderContext, IRenderPass nextPass)
         {
             renderContext.SpriteBatch.End();
         }


### PR DESCRIPTION
For the Protogame editor, we override EndRenderPass so that we can acquire a lock
on the render target before using it.