### PR TITLE
Force Hive session creation to be done on a background thread

### DIFF
--- a/Protogame/Hive/DefaultHiveSessionManagement.cs
+++ b/Protogame/Hive/DefaultHiveSessionManagement.cs
@@ -37,9 +37,14 @@ namespace Protogame
         {
             Init();
 
-            var session = await _temporarySessionApi.SessionPutAsync();
-            _tempSessions.Add(session);
-            return session;
+            // Ensure this does not run as part of a coroutine - force it to
+            // a background thread with Task.Run.
+            return await Task.Run(async () =>
+            {
+                var session = await _temporarySessionApi.SessionPutAsync();
+                _tempSessions.Add(session);
+                return session;
+            });
         }
 
         public IReadOnlyCollection<TempSessionWithSecrets> ActiveTemporarySessions => _tempSessions.AsReadOnly();


### PR DESCRIPTION
Previously it was possible to hit SessionPutAsync via a coroutine, which would stall the main thread.  This is just the first of many places where we probably need to guard API calls in Task.Run to ensure that the HTTP request work gets done on a background thread instead.