### PR TITLE
Allow UI children to be scrollable-aware

### DIFF
--- a/Build/Projects/Protogame.definition
+++ b/Build/Projects/Protogame.definition
@@ -835,6 +835,7 @@
     <Compile Include="UserInterface\Control\FileSelect.cs" />
     <Compile Include="UserInterface\Control\FontViewer.cs" />
     <Compile Include="UserInterface\Control\Form.cs" />
+    <Compile Include="UserInterface\Control\IScrollableAwareChild.cs" />
     <Compile Include="UserInterface\Control\Label.cs" />
     <Compile Include="UserInterface\Control\Link.cs" />
     <Compile Include="UserInterface\Control\LinkState.cs" />

--- a/Protogame/UserInterface/Control/Container/ScrollableContainer.cs
+++ b/Protogame/UserInterface/Control/Container/ScrollableContainer.cs
@@ -129,15 +129,37 @@ namespace Protogame
 
             try
             {
-                _child?.Render(
-                    context,
-                    skinLayout,
-                    skinDelegator,
-                    new Rectangle(
-                        -(int)(ScrollX * (System.Math.Max(childWidth, realLayoutWidth) - realLayoutWidth)),
-                        -(int)(ScrollY * (System.Math.Max(childHeight, realLayoutHeight) - realLayoutHeight)),
-                        childWidth,
-                        childHeight));
+                var scrollableChild = _child as IScrollableAwareChild;
+
+                if (scrollableChild != null)
+                {
+                    scrollableChild.Render(
+                        context,
+                        skinLayout,
+                        skinDelegator,
+                        new Rectangle(
+                            -(int)(ScrollX * (System.Math.Max(childWidth, realLayoutWidth) - realLayoutWidth)),
+                            -(int)(ScrollY * (System.Math.Max(childHeight, realLayoutHeight) - realLayoutHeight)),
+                            childWidth,
+                            childHeight),
+                        new Rectangle(
+                            0,
+                            0,
+                            realLayoutWidth,
+                            realLayoutHeight));
+                }
+                else
+                {
+                    _child?.Render(
+                        context,
+                        skinLayout,
+                        skinDelegator,
+                        new Rectangle(
+                            -(int)(ScrollX * (System.Math.Max(childWidth, realLayoutWidth) - realLayoutWidth)),
+                            -(int)(ScrollY * (System.Math.Max(childHeight, realLayoutHeight) - realLayoutHeight)),
+                            childWidth,
+                            childHeight));
+                }
             }
             finally
             {

--- a/Protogame/UserInterface/Control/IScrollableAwareChild.cs
+++ b/Protogame/UserInterface/Control/IScrollableAwareChild.cs
@@ -1,0 +1,9 @@
+﻿using Microsoft.Xna.Framework;
+
+namespace Protogame
+{
+    public interface IScrollableAwareChild
+    {
+        void Render(IRenderContext context, ISkinLayout skinLayout, ISkinDelegator skinDelegator, Rectangle layout, Rectangle renderedLayout);
+    }
+}

--- a/Protogame/UserInterface/Skin/DefaultSkinDelegator.cs
+++ b/Protogame/UserInterface/Skin/DefaultSkinDelegator.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.Xna.Framework;
 using Protoinject;
 
@@ -22,6 +23,20 @@ namespace Protogame
         {
             var implementation = _kernel.Get<ISkinRenderer<TContainer>>();
             return implementation.MeasureText(context, text, container);
+        }
+
+        public void Render<TContainer>(IRenderContext renderContext, Rectangle layout, Rectangle renderedLayout, TContainer container) where TContainer : IContainer
+        {
+            var implementation = _kernel.Get<ISkinRenderer<TContainer>>();
+            var scrollableImplementation = implementation as IScrollableAwareSkinRenderer<TContainer>;
+            if (scrollableImplementation != null)
+            {
+                scrollableImplementation.Render(renderContext, layout, renderedLayout, container);
+            }
+            else
+            {
+                implementation.Render(renderContext, layout, container);
+            }
         }
     }
 }

--- a/Protogame/UserInterface/Skin/ISkinDelegator.cs
+++ b/Protogame/UserInterface/Skin/ISkinDelegator.cs
@@ -9,6 +9,12 @@ namespace Protogame
             Rectangle layout,
             TContainer container) where TContainer : IContainer;
 
+        void Render<TContainer>(
+            IRenderContext renderContext,
+            Rectangle layout,
+            Rectangle renderedLayout,
+            TContainer container) where TContainer : IContainer;
+
         Vector2 MeasureText<TContainer>(IRenderContext context, string text, TContainer container)
             where TContainer : IContainer;
     }

--- a/Protogame/UserInterface/Skin/ISkinRenderer.cs
+++ b/Protogame/UserInterface/Skin/ISkinRenderer.cs
@@ -11,4 +11,13 @@ namespace Protogame
 
         Vector2 MeasureText(IRenderContext renderContext, string text, TContainer container);
     }
+
+    public interface IScrollableAwareSkinRenderer<in TContainer> : ISkinRenderer<TContainer> where TContainer : IContainer
+    {
+        void Render(
+            IRenderContext renderContext,
+            Rectangle layout,
+            Rectangle renderedLayout,
+            TContainer container);
+    }
 }


### PR DESCRIPTION
This adds a new interface IScrollableAwareChild and an accompanying IScrollableAwareSkinRenderer interface for skin renderers.  When the scrollable container goes to render it's child, it will pass an additional rectangle indicating the area which will actually end up on screen.  This allows child controls to omit draw calls which are outside of the visible scrolled area.