### PR TITLE
Add interlaced depth API

### DIFF
--- a/Build/Projects/Protogame.definition
+++ b/Build/Projects/Protogame.definition
@@ -438,6 +438,7 @@
     <Compile Include="Graphics\DefaultCustomPostProcessingRenderPass.cs" />
     <Compile Include="Graphics\DefaultDebugRenderPass.cs" />
     <Compile Include="Graphics\DefaultGraphicsBlit.cs" />
+    <Compile Include="Graphics\DefaultInterlacedBatchingDepthProvider.cs" />
     <Compile Include="Graphics\DefaultInvertPostProcessingRenderPass.cs" />
     <Compile Include="Graphics\DefaultRenderAutoCache.cs" />
     <Compile Include="Graphics\DefaultRenderCache.cs" />
@@ -486,6 +487,7 @@
     <Compile Include="Graphics\IDebugRenderPass.cs" />
     <Compile Include="Graphics\IGraphicsBlit.cs" />
     <Compile Include="Graphics\IGraphicsFactory.cs" />
+    <Compile Include="Graphics\IInterlacedBatchingDepthProvider.cs" />
     <Compile Include="Graphics\IInvertPostProcessingRenderPass.cs" />
     <Compile Include="Graphics\IRenderAutoCache.cs" />
     <Compile Include="Graphics\IRenderCache.cs" />

--- a/Protogame/Core/Default2DRenderUtilities.cs
+++ b/Protogame/Core/Default2DRenderUtilities.cs
@@ -16,11 +16,14 @@ namespace Protogame
     public class Default2DRenderUtilities : I2DRenderUtilities
     {
         private readonly IStringSanitizer _stringSanitizer;
+        private readonly IInterlacedBatchingDepthProvider _interlacedBatchingDepthProvider;
 
         public Default2DRenderUtilities(
-            IStringSanitizer stringSanitizer)
+            IStringSanitizer stringSanitizer,
+            IInterlacedBatchingDepthProvider interlacedBatchingDepthProvider)
         {
             _stringSanitizer = stringSanitizer;
+            _interlacedBatchingDepthProvider = interlacedBatchingDepthProvider;
         }
         
         public Vector2 MeasureText(IRenderContext context, string text, IAssetReference<FontAsset> font)
@@ -61,8 +64,8 @@ namespace Protogame
                 angle, 
                 Vector2.Zero, 
                 new Vector2(length, width), 
-                SpriteEffects.None, 
-                0);
+                SpriteEffects.None,
+                _interlacedBatchingDepthProvider.GetDepthForCurrentInstance());
         }
         
         public void RenderRectangle(IRenderContext context, Rectangle rectangle, Color color, bool filled = false)
@@ -197,11 +200,11 @@ namespace Protogame
             // Draw shadow if required.
             if (renderShadow)
             {
-                context.SpriteBatch.DrawString(font.Asset.Font, text, new Vector2(xx, yy) + (scale ?? Vector2.One), shadowColor.Value, rotation ?? 0, origin ?? Vector2.Zero, scale ?? Vector2.One, SpriteEffects.None, 0);
+                context.SpriteBatch.DrawString(font.Asset.Font, text, new Vector2(xx, yy) + (scale ?? Vector2.One), shadowColor.Value, rotation ?? 0, origin ?? Vector2.Zero, scale ?? Vector2.One, SpriteEffects.None, _interlacedBatchingDepthProvider.GetDepthForCurrentInstance());
             }
 
             // Render the main text.
-            context.SpriteBatch.DrawString(font.Asset.Font, text, new Vector2(xx, yy), textColor.Value, rotation ?? 0, origin ?? Vector2.Zero, scale ?? Vector2.One, SpriteEffects.None, 0);
+            context.SpriteBatch.DrawString(font.Asset.Font, text, new Vector2(xx, yy), textColor.Value, rotation ?? 0, origin ?? Vector2.Zero, scale ?? Vector2.One, SpriteEffects.None, _interlacedBatchingDepthProvider.GetDepthForCurrentInstance());
         }
         
         public void RenderTexture(
@@ -282,7 +285,7 @@ namespace Protogame
                 rotation,
                 rotationAnchor ?? Vector2.Zero,
                 effects,
-                0);
+                _interlacedBatchingDepthProvider.GetDepthForCurrentInstance());
         }
         
         public void RenderCircle(

--- a/Protogame/Core/ProtogameCoreModule.cs
+++ b/Protogame/Core/ProtogameCoreModule.cs
@@ -66,6 +66,8 @@ namespace Protogame
             kernel.Bind<IRenderBatcher>().To<DefaultRenderBatcher>().InSingletonScope();
 
             kernel.Bind<ILoadingScreen>().To<DefaultLoadingScreen>().InSingletonScope();
+
+            kernel.Bind<IInterlacedBatchingDepthProvider>().To<DefaultInterlacedBatchingDepthProvider>().InSingletonScope();
         }
     }
 }

--- a/Protogame/Graphics/Default2DBatchedRenderPass.cs
+++ b/Protogame/Graphics/Default2DBatchedRenderPass.cs
@@ -13,6 +13,13 @@ namespace Protogame
     /// <interface_ref>Protogame.I2DBatchedRenderPass</interface_ref>
     public class Default2DBatchedRenderPass : I2DBatchedRenderPass
     {
+        private readonly IInterlacedBatchingDepthProvider _interlacedBatchingDepthProvider;
+
+        public Default2DBatchedRenderPass(IInterlacedBatchingDepthProvider interlacedBatchingDepthProvider)
+        {
+            _interlacedBatchingDepthProvider = interlacedBatchingDepthProvider;
+        }
+
         public bool IsPostProcessingPass => false;
         public bool SkipWorldRenderBelow => false;
         public bool SkipWorldRenderAbove => false;
@@ -32,6 +39,8 @@ namespace Protogame
 
         public void BeginRenderPass(IGameContext gameContext, IRenderContext renderContext, IRenderPass previousPass, RenderTarget2D postProcessingSource)
         {
+            _interlacedBatchingDepthProvider.Reset();
+
             renderContext.SpriteBatch.Begin(TextureSortMode, transformMatrix: TransformMatrix);
         }
 

--- a/Protogame/Graphics/Default2DDirectRenderPass.cs
+++ b/Protogame/Graphics/Default2DDirectRenderPass.cs
@@ -11,6 +11,13 @@ namespace Protogame
     /// <interface_ref>Protogame.I2DDirectRenderPass</interface_ref>
     public class Default2DDirectRenderPass : I2DDirectRenderPass
     {
+        private readonly IInterlacedBatchingDepthProvider _interlacedBatchingDepthProvider;
+
+        public Default2DDirectRenderPass(IInterlacedBatchingDepthProvider interlacedBatchingDepthProvider)
+        {
+            _interlacedBatchingDepthProvider = interlacedBatchingDepthProvider;
+        }
+
         public bool IsPostProcessingPass => false;
         public bool SkipWorldRenderBelow => false;
         public bool SkipWorldRenderAbove => false;
@@ -26,6 +33,8 @@ namespace Protogame
 
         public void BeginRenderPass(IGameContext gameContext, IRenderContext renderContext, IRenderPass previousPass, RenderTarget2D postProcessingSource)
         {
+            _interlacedBatchingDepthProvider.Reset();
+
             // Setup the default sprite effect.
             var vp = Viewport ?? renderContext.GraphicsDevice.Viewport;
 

--- a/Protogame/Graphics/DefaultCanvasRenderPass.cs
+++ b/Protogame/Graphics/DefaultCanvasRenderPass.cs
@@ -12,13 +12,14 @@ namespace Protogame
     public class DefaultCanvasRenderPass : ICanvasRenderPass
     {
         private readonly IBackBufferDimensions _backBufferDimensions;
-
+        private readonly IInterlacedBatchingDepthProvider _interlacedBatchingDepthProvider;
+        
         public DefaultCanvasRenderPass(
-            IBackBufferDimensions backBufferDimensions)
+            IBackBufferDimensions backBufferDimensions,
+            IInterlacedBatchingDepthProvider interlacedBatchingDepthProvider)
         {
             _backBufferDimensions = backBufferDimensions;
-
-            TextureSortMode = SpriteSortMode.Immediate;
+            _interlacedBatchingDepthProvider = interlacedBatchingDepthProvider;
         }
 
         public bool IsPostProcessingPass => false;
@@ -38,6 +39,8 @@ namespace Protogame
 
         public virtual void BeginRenderPass(IGameContext gameContext, IRenderContext renderContext, IRenderPass previousPass, RenderTarget2D postProcessingSource)
         {
+            _interlacedBatchingDepthProvider.Reset();
+
             if (Viewport != null)
             {
                 renderContext.GraphicsDevice.Viewport = Viewport.Value;

--- a/Protogame/Graphics/DefaultInterlacedBatchingDepthProvider.cs
+++ b/Protogame/Graphics/DefaultInterlacedBatchingDepthProvider.cs
@@ -1,0 +1,25 @@
+﻿#pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
+
+namespace Protogame
+{
+    public class DefaultInterlacedBatchingDepthProvider : IInterlacedBatchingDepthProvider
+    {
+        private float _currentDepth;
+
+        public float GetDepthForCurrentInstance()
+        {
+            var d = _currentDepth;
+            _currentDepth -= 0.00001f;
+            if (_currentDepth <= 0)
+            {
+                _currentDepth = 0f;
+            }
+            return d;
+        }
+
+        public void Reset()
+        {
+            _currentDepth = 1f;
+        }
+    }
+}

--- a/Protogame/Graphics/IInterlacedBatchingDepthProvider.cs
+++ b/Protogame/Graphics/IInterlacedBatchingDepthProvider.cs
@@ -1,0 +1,15 @@
+﻿namespace Protogame
+{
+    /// <summary>
+    /// Provides depth values for SpriteBatch and other interlaced draw calls such that
+    /// you can use SpriteBatch in deferred mode, draw non-SpriteBatch'd vertexes in the
+    /// middle, and still have the correct result.
+    /// </summary>
+    /// <module>Graphics</module>
+    public interface IInterlacedBatchingDepthProvider
+    {
+        void Reset();
+
+        float GetDepthForCurrentInstance();
+    }
+}


### PR DESCRIPTION
This adds an IInterlacedBatchingDepthProvider which provides depth values for draw calls interlaced with a SpriteBatch in deferred mode.  If you use this interface to provide depth values to SpriteBatch (as I2DRenderUtilities does for you), you can then draw lines and triangles on the GPU directly while still having the SpriteBatch in deferred mode, which can save on draw calls.