### PR TITLE
Check to ensure the game is active before processing events

### DIFF
--- a/Protogame/Core/CoreGame.cs
+++ b/Protogame/Core/CoreGame.cs
@@ -216,6 +216,14 @@ namespace Protogame
             set { if (_hostGame != null) { _hostGame.IsMouseVisible = value; } }
         }
 
+        public bool IsActive
+        {
+            get
+            {
+                return _hostGame?.IsActive ?? false;
+            }
+        }
+
         /// <summary>
         /// Initializes an instance of a game in Protogame.  This constructor is always called
         /// as the base constructor to your game implementation.

--- a/Protogame/Core/ICoreGame.cs
+++ b/Protogame/Core/ICoreGame.cs
@@ -24,6 +24,8 @@ namespace Protogame
 
         bool HasLoadedContent { get; }
 
+        bool IsActive { get; }
+
         void AssignHost(IHostGame hostGame);
 
         void EnableImmediateStartFromHost();

--- a/Protogame/Core/IHostGame.cs
+++ b/Protogame/Core/IHostGame.cs
@@ -28,5 +28,7 @@ namespace Protogame
         SpriteBatch SplashScreenSpriteBatch { get; }
 
         Texture2D SplashScreenTexture { get; }
+
+        bool IsActive { get; }
     }
 }

--- a/Protogame/Events/EventEngineHook.cs
+++ b/Protogame/Events/EventEngineHook.cs
@@ -91,6 +91,11 @@ namespace Protogame
         /// </param>
         public void Update(IGameContext gameContext, IUpdateContext updateContext)
         {
+            if (!gameContext.Game.IsActive)
+            {
+                return;
+            }
+
             UpdateKeyboard(gameContext);
             UpdateMouse(gameContext);
 


### PR DESCRIPTION
XNA/MonoGame captures all mouse and keyboard events, even when the window doesn't have focus.  This doesn't make a lot of sense (because it means you can click through other applications to the game window behind them), so this change ensures that the event engine hook checks to see if the game is active before firing any kind of event.