### PR TITLE
Add IGameWindow.GetCursorPosition

### DIFF
--- a/Protogame/Core/IGameWindow.cs
+++ b/Protogame/Core/IGameWindow.cs
@@ -49,7 +49,14 @@ namespace Protogame
         /// <param name="x">The horizontal position of the cursor.</param>
         /// <param name="y">The vertical position of the cursor.</param>
         void SetCursorPosition(int x, int y);
-
+        
+        /// <summary>
+        /// Gets the position of the mouse cursor on the screen, relative to the window.
+        /// </summary>
+        /// <param name="x">The horizontal position of the cursor.</param>
+        /// <param name="y">The vertical position of the cusor.</param>
+        void GetCursorPosition(out int x, out int y);
+        
 #if PLATFORM_WINDOWS
         void Maximize();
 

--- a/Protogame/Graphics/RenderPipelineRenderContext.cs
+++ b/Protogame/Graphics/RenderPipelineRenderContext.cs
@@ -329,8 +329,9 @@ namespace Protogame
             }
 
             // Update the MouseRay property of the game context.
-            var mouseState = Mouse.GetState();
-            var mouse = new Vector2(mouseState.X, mouseState.Y);
+            int mouseX, mouseY;
+            context.Window.GetCursorPosition(out mouseX, out mouseY);
+            var mouse = new Vector2(mouseX, mouseY);
             var nearSource = new Vector3(mouse, 0f);
             var farSource = new Vector3(mouse, 1f);
 
@@ -360,7 +361,7 @@ namespace Protogame
             // the game context if we were able to resolve the mouse ray.
             if (direction != Vector3.Zero)
             {
-                var nearSourceHorizontal = new Vector3(mouseState.X + 1, mouseState.Y, 0f);
+                var nearSourceHorizontal = new Vector3(mouseX + 1, mouseY, 0f);
                 var nearPointHorizontal = this.GraphicsDevice.Viewport.Unproject(
                     nearSourceHorizontal,
                     this.Projection,
@@ -369,7 +370,7 @@ namespace Protogame
 
                 context.MouseVerticalPlane = new Plane(nearSource, nearSource + direction, nearPointHorizontal);
 
-                var nearSourceVertical = new Vector3(mouseState.X, mouseState.Y + 1, 0f);
+                var nearSourceVertical = new Vector3(mouseX, mouseY + 1, 0f);
                 var nearPointVertical = this.GraphicsDevice.Viewport.Unproject(
                     nearSourceVertical,
                     this.Projection,

--- a/Protogame/Platform/AndroidGameWindow.cs
+++ b/Protogame/Platform/AndroidGameWindow.cs
@@ -84,6 +84,12 @@ namespace Protogame
         public void SetCursorPosition(int x, int y)
         {
         }
+
+        public void GetCursorPosition(out int x, out int y)
+        {
+            x = 0;
+            y = 0;
+        }
     }
 }
 #endif

--- a/Protogame/Platform/DefaultGameWindow.cs
+++ b/Protogame/Platform/DefaultGameWindow.cs
@@ -68,6 +68,13 @@ namespace Protogame
             Mouse.SetPosition(x, y);
         }
 
+        public void GetCursorPosition(out int x, out int y)
+        {
+            var state = Mouse.GetState();
+            x = state.X;
+            y = state.Y;
+        }
+
 #if PLATFORM_WINDOWS
         public void Maximize()
         {


### PR DESCRIPTION
The mouse ray and plane calculations currently rely on Mouse.GetState, which doesn't work in hosted contexts.  This adds a GetCursorPosition to the game window API so that these rays and planes can be calculated even when the game is running inside an editor.