### PR TITLE
Add PostPreRender to IRenderContext so rays are calculated correctly

### DIFF
--- a/Protogame/Core/IRenderContext.cs
+++ b/Protogame/Core/IRenderContext.cs
@@ -146,6 +146,14 @@ namespace Protogame
         void Render(IGameContext context);
 
         /// <summary>
+        /// Called by the render pipeline after entity pre-render has been done, but before entity render
+        /// has begun.  This method is where the render context updates the mouse rays and planes in
+        /// the game context, based on the current rendering configuration.
+        /// </summary>
+        /// <param name="context">The current game context.</param>
+        void PostPreRender(IGameContext context);
+
+        /// <summary>
         /// Adds the specified render pass to the render pipeline
         /// permanently.  This render pass will take effect after the
         /// start of the next frame.

--- a/Protogame/Graphics/DefaultRenderPipeline.cs
+++ b/Protogame/Graphics/DefaultRenderPipeline.cs
@@ -409,10 +409,16 @@ namespace Protogame
                     entity.Prerender(gameContext, renderContext);
                 }
 
+                renderContext.PostPreRender(gameContext);
+
                 foreach (var entity in entities)
                 {
                     entity.Render(gameContext, renderContext);
                 }
+            }
+            else
+            {
+                renderContext.PostPreRender(gameContext);
             }
 
             if (!renderPass.SkipWorldRenderAbove && gameContext.World != null)

--- a/Protogame/Graphics/RenderPipelineRenderContext.cs
+++ b/Protogame/Graphics/RenderPipelineRenderContext.cs
@@ -328,6 +328,11 @@ namespace Protogame
                 this.SingleWhitePixel.SetData(new[] { Color.White });
             }
 
+            PostPreRender(context);
+        }
+
+        public void PostPreRender(IGameContext context)
+        { 
             // Update the MouseRay property of the game context.
             var mouseState = Mouse.GetState();
             var mouse = new Vector2(mouseState.X, mouseState.Y);

--- a/Protogame/Server/NullRenderContext.cs
+++ b/Protogame/Server/NullRenderContext.cs
@@ -58,6 +58,11 @@ namespace Protogame
             throw new NotSupportedException();
         }
 
+        public void PostPreRender(IGameContext context)
+        {
+            throw new NotSupportedException();
+        }
+
         public void SetActiveTexture(Texture2D texture)
         {
             throw new NotSupportedException();


### PR DESCRIPTION
Previously the mouse ray and plane calculations were done at the start of the render pipeline. However, this is not correct as cameras are setup during the Prerender call of entities, which happens much later, and happens per-render pass.

This moves the ray calculations into a PostPreRender call on IRenderContext, which is called automatically by the render pipeline between Prerender and Render, and can optionally be called by developers if the view or projection changes at any other time during rendering and the mouse ray and plane need to be recalculated on game context.