### PR TITLE
Only use compiled platform asset locations when running in Release mode

### DIFF
--- a/Protogame/Assets/ProtogameAssetModule.cs
+++ b/Protogame/Assets/ProtogameAssetModule.cs
@@ -41,8 +41,10 @@ namespace Protogame
             kernel.Bind<IAssetFsLayer>().To<SourceEmbeddedAssetFsLayer>().InSingletonScope();
             kernel.Bind<IAssetFsLayer>().To<CompiledEmbeddedAssetFsLayer>().InSingletonScope();
 #if PLATFORM_WINDOWS || PLATFORM_MACOS || PLATFORM_LINUX
+#if DEBUG
             kernel.Bind<IAssetFsLayer>().To<SourceDirLocalFilesystemAssetFsLayer>().InSingletonScope();
             kernel.Bind<IAssetFsLayer>().To<CurrentDirLocalFilesystemAssetFsLayer>().InSingletonScope();
+#endif
             kernel.Bind<IAssetFsLayer>().To<CurrentDirPlatformLocalFilesystemAssetFsLayer>().InSingletonScope();
 #elif PLATFORM_ANDROID
 #if DEBUG


### PR DESCRIPTION
When games are packaged using content projects, by default they include source assets even in Release builds.  When unpacked by third-party tools or distribution mechanisms like the itch.io app, the last modified dates on assets are not useful enough to determine whether the compiled version is later than the source version, and this results in the Release build trying to compile source assets for which it has no compiler (because compilers are not included in Release builds).

This updates the asset filesystem layer configuration so that Release builds only include the platform-specific, compiled asset location.