### PR TITLE
Use new GraphicsDebug API in MonoGame to report DirectX messages to the console

### DIFF
--- a/Build/Projects/Protogame.definition
+++ b/Build/Projects/Protogame.definition
@@ -356,6 +356,7 @@
     <Compile Include="Coroutine\ICoroutineScheduler.cs" />
     <Compile Include="Coroutine\ProtogameCoroutineModule.cs" />
     <Compile Include="Debug\DefaultDebugRenderer.cs" />
+    <Compile Include="Debug\GraphicsDebugEngineHook.cs" />
     <Compile Include="Debug\IDebugLayer.cs" />
     <Compile Include="Debug\IDebugRenderer.cs" />
     <Compile Include="Debug\NullDebugRenderer.cs" />

--- a/Protogame/Debug/GraphicsDebugEngineHook.cs
+++ b/Protogame/Debug/GraphicsDebugEngineHook.cs
@@ -1,0 +1,47 @@
+﻿namespace Protogame
+{
+    public class GraphicsDebugEngineHook : IEngineHook
+    {
+        private readonly IConsoleHandle _consoleHandle;
+
+        public GraphicsDebugEngineHook(IConsoleHandle consoleHandle)
+        {
+            _consoleHandle = consoleHandle;
+        }
+
+        public void Render(IGameContext gameContext, IRenderContext renderContext)
+        {
+#if PLATFORM_WINDOWS
+            Microsoft.Xna.Framework.Graphics.GraphicsDebugMessage message;
+
+            if (renderContext.GraphicsDevice.GraphicsDebug != null)
+            {
+                while (renderContext.GraphicsDevice.GraphicsDebug.TryDequeueMessage(out message))
+                {
+                    switch (message.Severity)
+                    {
+                        case "Corruption":
+                        case "Error":
+                            _consoleHandle.LogError("DX11 ({0}) ({1}, {2}): {3}", message.Severity, message.Category, message.IdName, message.Message);
+                            break;
+                        case "Warning":
+                            _consoleHandle.LogWarning("DX11 ({0}) ({1}, {2}): {3}", message.Severity, message.Category, message.IdName, message.Message);
+                            break;
+                        case "Information":
+                            _consoleHandle.LogDebug("DX11 ({0}) ({1}, {2}): {3}", message.Severity, message.Category, message.IdName, message.Message);
+                            break;
+                    }
+                }
+            }
+#endif
+        }
+
+        public void Update(IGameContext gameContext, IUpdateContext updateContext)
+        {
+        }
+
+        public void Update(IServerContext serverContext, IUpdateContext updateContext)
+        {
+        }
+    }
+}

--- a/Protogame/Debug/ProtogameDebugModule.cs
+++ b/Protogame/Debug/ProtogameDebugModule.cs
@@ -16,6 +16,7 @@ namespace Protogame
         public void Load(IKernel kernel)
         {
             kernel.Rebind<IDebugRenderer>().To<DefaultDebugRenderer>().InSingletonScope();
+            kernel.Bind<IEngineHook>().To<GraphicsDebugEngineHook>().InSingletonScope();
         }
     }
 }


### PR DESCRIPTION
This should help diagnose any graphics rendering issues caused by invalid shaders, as those shader errors will now appear in the console as well.

This won't successfully build until https://github.com/RedpointGames/MonoGame/pull/114 is merged.