### PR TITLE
Skip render pipeline tests if no graphics device

### DIFF
--- a/Protogame.Tests/RenderPipelineTests.cs
+++ b/Protogame.Tests/RenderPipelineTests.cs
@@ -340,9 +340,16 @@ namespace Protogame.Tests
             kernel.Bind<ITestAttachment>().ToMethod(x => _testAttachment);
             kernel.Bind<IRawLaunchArguments>().ToMethod(x => new DefaultRawLaunchArguments(new string[0]));
 
-            using (var game = new HostGame(new RenderPipelineGame(kernel)))
+            try
             {
-                game.Run();
+                using (var game = new HostGame(new RenderPipelineGame(kernel)))
+                {
+                    game.Run();
+                }
+            }
+            catch (Microsoft.Xna.Framework.Graphics.NoSuitableGraphicsDeviceException)
+            {
+                System.Console.Error.WriteLine("WARNING: Unable to perform render pipeline tests as no graphics device could be found!");
             }
         }
     }


### PR DESCRIPTION
Allow the render pipeline tests to be skipped only in the scenario where no graphics device is available.  Occasionally the build server loses the ability to use the graphics device (usually due to remoting into the service and killing the session attached to the physical screen).  When this occurs over the weekend, there's no way to restore session 0 so that the tests will pass again.  During this time, we want to allow builds to continue to pass.