### PR TITLE
Move NetIDCommand binding to network module

### DIFF
--- a/Protogame/Core/ProtogameCoreModule.cs
+++ b/Protogame/Core/ProtogameCoreModule.cs
@@ -31,7 +31,6 @@ namespace Protogame
             kernel.Bind<ICommand>().To<ExitCommand>().DiscardNodeOnResolve();
             kernel.Bind<ICommand>().To<HelpCommand>().DiscardNodeOnResolve();
             kernel.Bind<ICommand>().To<GCCommand>().DiscardNodeOnResolve();
-            kernel.Bind<ICommand>().To<NetIDCommand>().DiscardNodeOnResolve();
 
             kernel.Bind<IRenderContext>().To<RenderPipelineRenderContext>().InParentScope();
             kernel.Bind<IRenderPipeline>().To<DefaultRenderPipeline>().InParentScope();

--- a/Protogame/Network/ProtogameNetworkModule.cs
+++ b/Protogame/Network/ProtogameNetworkModule.cs
@@ -18,6 +18,8 @@ namespace Protogame
 
             kernel.Bind<INetworkMessage>().To<EntityCreateMessage>().InSingletonScope();
             kernel.Bind<INetworkMessage>().To<EntityPropertiesMessage>().InSingletonScope();
+            
+            kernel.Bind<ICommand>().To<NetIDCommand>().DiscardNodeOnResolve();
         }
     }
 }


### PR DESCRIPTION
This would cause a binding resolution failure because NetIDCommand depends on network engine.  This binding should be in the network module instead.