### PR TITLE
Disable visual tests on Linux

### DIFF
--- a/Protogame.Tests/RenderPipelineTests.cs
+++ b/Protogame.Tests/RenderPipelineTests.cs
@@ -329,6 +329,10 @@ namespace Protogame.Tests
         
         public void PerformRenderPipelineTest()
         {
+#if PLATFORM_LINUX
+            return;
+#endif
+
             // We must change directory to the location of the assembly, because
             // Linux doesn't load SDL DLLs properly.
             Environment.CurrentDirectory = new FileInfo(Assembly.GetEntryAssembly().Location).DirectoryName;


### PR DESCRIPTION
These are apparently broken again, despite no changes to the code. They're super finicky because of their reliance on a headless X server with Mesa support, so we're going to disable them for now until we have something more reliable.